### PR TITLE
✨ Feat: #10 Dropdown 공통 컴포넌트 추가

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -9,7 +9,10 @@
   "endOfLine": "auto",
   "bracketSpacing": true,
   "bracketSameLine": false,
-  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "plugins": [
+    "@trivago/prettier-plugin-sort-imports",
+    "prettier-plugin-tailwindcss"
+  ],
   "importOrder": [
     "^react(.*)",
     "^next(.*)",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "@typescript-eslint/parser": "^6.8.0",
     "autoprefixer": "^10.4.16",
+    "clsx": "^2.0.0",
     "eslint": "^8",
     "eslint-config-next": "13.5.6",
     "eslint-config-prettier": "^9.0.0",
@@ -38,6 +39,7 @@
     "lint-staged": "^15.0.2",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",
+    "prettier-plugin-tailwindcss": "^0.5.6",
     "tailwindcss": "^3.3.3",
     "typescript": "^5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ devDependencies:
   autoprefixer:
     specifier: ^10.4.16
     version: 10.4.16(postcss@8.4.31)
+  clsx:
+    specifier: ^2.0.0
+    version: 2.0.0
   eslint:
     specifier: ^8
     version: 8.0.0
@@ -85,6 +88,9 @@ devDependencies:
   prettier:
     specifier: ^3.0.3
     version: 3.0.3
+  prettier-plugin-tailwindcss:
+    specifier: ^0.5.6
+    version: 0.5.6(@trivago/prettier-plugin-sort-imports@4.2.0)(prettier@3.0.3)
   tailwindcss:
     specifier: ^3.3.3
     version: 3.3.3
@@ -2137,6 +2143,11 @@ packages:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: false
 
+  /clsx@2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
+    dev: true
+
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
@@ -3946,6 +3957,62 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       fast-diff: 1.3.0
+    dev: true
+
+  /prettier-plugin-tailwindcss@0.5.6(@trivago/prettier-plugin-sort-imports@4.2.0)(prettier@3.0.3):
+    resolution: {integrity: sha512-2Xgb+GQlkPAUCFi3sV+NOYcSI5XgduvDBL2Zt/hwJudeKXkyvRS65c38SB0yb9UB40+1rL83I6m0RtlOQ8eHdg==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@shufo/prettier-plugin-blade': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+      prettier-plugin-twig-melody: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@shufo/prettier-plugin-blade':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      prettier-plugin-twig-melody:
+        optional: true
+    dependencies:
+      '@trivago/prettier-plugin-sort-imports': 4.2.0(prettier@3.0.3)
+      prettier: 3.0.3
     dev: true
 
   /prettier@3.0.3:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { Theme } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 import "./global.css";
 
@@ -19,7 +20,9 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       lang="ko"
       className={inter.className}
     >
-      <body>{children}</body>
+      <body>
+        <Theme>{children}</Theme>
+      </body>
     </html>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "@radix-ui/themes/styles.css";
 import "./global.css";
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Steady",
@@ -9,7 +15,10 @@ export const metadata: Metadata = {
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <html lang="ko">
+    <html
+      lang="ko"
+      className={inter.className}
+    >
       <body>{children}</body>
     </html>
   );

--- a/src/components/_common/Dropdown/index.tsx
+++ b/src/components/_common/Dropdown/index.tsx
@@ -27,7 +27,7 @@ const Dropdown = ({ children, options }: DropdownProps) => {
         {options.map((option, idx) => (
           <DropdownMenu.Item
             key={idx}
-            className={"hover:bg-steady-main-color"}
+            className={"hover:bg-st-primary"}
           >
             <Link href={option.linkTo}>{option.label}</Link>
           </DropdownMenu.Item>

--- a/src/components/_common/Dropdown/index.tsx
+++ b/src/components/_common/Dropdown/index.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Button, DropdownMenu } from "@radix-ui/themes";
+
+interface OptionsType {
+  label: string;
+  linkTo: string;
+}
+
+interface DropdownProps {
+  children: ReactNode;
+  options: OptionsType[];
+}
+
+const Dropdown = ({ children, options }: DropdownProps) => {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <Button
+          variant={"ghost"}
+          className={"hover:bg-transparent"}
+        >
+          {children}
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        {options.map((option, idx) => (
+          <DropdownMenu.Item
+            key={idx}
+            className={"hover:bg-steady-main-color"}
+          >
+            <Link href={option.linkTo}>{option.label}</Link>
+          </DropdownMenu.Item>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+};
+
+export default Dropdown;

--- a/src/components/_common/Dropdown/index.tsx
+++ b/src/components/_common/Dropdown/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { Button, DropdownMenu } from "@radix-ui/themes";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,6 @@ module.exports = {
       padding: px0_100,
       spacing: px0_200,
     },
+    plugins: [],
   },
-  plugins: [],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,15 @@
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
+    colors: {
+      "st-primary": "#5585ff",
+      "st-red": "#ff5353",
+      "st-green": "#35cc00",
+      "st-gray-100": "#b4b4b4",
+      "st-gray-200": "#8a8a8a",
+      "st-gray-250": "#858585",
+      "st-gray-400": "#6c6c6c",
+    },
     extend: {},
   },
   plugins: [],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,9 @@
 /** @type {import('tailwindcss').Config} */
+const px0_10 = { ...Array.from(Array(11)).map((_, i) => `${i}px`) };
+const px0_100 = { ...Array.from(Array(101)).map((_, i) => `${i}px`) };
+const px0_200 = { ...Array.from(Array(201)).map((_, i) => `${i}px`) };
+const px0_1300 = { ...Array.from(Array(1301)).map((_, i) => `${i}px`) };
+
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
@@ -11,7 +16,19 @@ module.exports = {
       "st-gray-250": "#858585",
       "st-gray-400": "#6c6c6c",
     },
-    extend: {},
+    extend: {
+      width: px0_1300,
+      height: px0_1300,
+      borderWidth: px0_10,
+      borderRadius: px0_100,
+      fontSize: px0_100,
+      lineHeight: px0_100,
+      minWidth: px0_200,
+      minHeight: px0_200,
+      margin: px0_100,
+      padding: px0_100,
+      spacing: px0_200,
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
- tailwind 설정에 Steady 메인 색상 정보 추가

## 📑 구현 사항

- [x] Dropdown 공통 컴포넌트를 만들었습니다
- [x] Dropdown은 Avatar 등의 컴포넌트를 children을 prop으로 받을 수 있습니다.

## 테스트 코드
```tsx
<Dropdown children={<Avatar size={"3"} radius={"full"} src={"https://images.unsplash.com/photo-1502823403499-6ccfcf4fb453?&w=256&h=256&q=70&crop=focalpoint&fp-x=0.5&fp-y=0.3&fp-z=1&fit=crop"} fallback={'A'}/>} options={[{label:'마이페이지', linkTo:'/mypage'}, {label: '로그아웃', linkTo: '/logout'} ]} />
```
위 코드를 pages.tsx에서 렌더링하면 아래처럼 작동하는 컴포넌트를 볼 수 있습니다!
![Oct-24-2023 18-55-35](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/aa0786c6-327b-4caa-ad61-f4a2eeb19c4e)


## 🚧 특이 사항

- 드롭다운 메뉴를 클릭하면 children 주변의 색깔이 변하는데, 이걸 그대로 둬도 괜찮은지 궁금하네여


## 🚨관련 이슈

#10 