### PR TITLE
✨ Feat: #3 - 공통 컴포넌트 ListItem 추가

### DIFF
--- a/src/components/_common/ListItem/index.tsx
+++ b/src/components/_common/ListItem/index.tsx
@@ -1,10 +1,8 @@
-import type { ReactNode } from "react";
 import Icon from "@/components/Icon";
 import clsx from "clsx";
 import type { SteadyInfoType } from "@/app/page";
 
 interface ListItemProps {
-  children?: ReactNode;
   object: SteadyInfoType[];
   className?: string;
   listType: "steady" | "form";

--- a/src/components/_common/ListItem/index.tsx
+++ b/src/components/_common/ListItem/index.tsx
@@ -17,7 +17,7 @@ const ListItem = ({ className, object, listType }: ListItemProps) => {
         <div
           key={id}
           className={clsx(
-            "border-black flex h-140 cursor-pointer items-center justify-between border-2 border-solid px-40 py-50",
+            "flex h-140 cursor-pointer items-center justify-between px-40 py-50",
             className,
           )}
         >

--- a/src/components/_common/ListItem/index.tsx
+++ b/src/components/_common/ListItem/index.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import Icon from "@/components/Icon";
+import clsx from "clsx";
+import type { SteadyInfoType } from "@/app/page";
+
+interface ListItemProps {
+  children?: ReactNode;
+  object: SteadyInfoType[];
+  className?: string;
+  listType: "steady" | "form";
+}
+
+const ListItem = ({ className, object, listType }: ListItemProps) => {
+  return (
+    <div>
+      {object.map((item, id) => (
+        <div
+          key={id}
+          className={clsx(
+            "border-black flex h-140 cursor-pointer items-center justify-between border-2 border-solid px-40 py-50",
+            className,
+          )}
+        >
+          <div className="text-black text-26 font-bold">{item.title}</div>
+          <div className="flex items-center justify-center">
+            <div className="flex items-center justify-center gap-30">
+              <div className="text-bold text-15 text-st-gray-100">
+                생성일 {item.createdAt}
+              </div>
+              {item.isAdmin && (
+                <>
+                  {listType === "steady" ? (
+                    <>
+                      <Icon label={"config"} />
+                      <Icon label={"trash"} />
+                    </>
+                  ) : (
+                    <>
+                      <Icon label={"edit"} />
+                      <Icon label={"trash"} />
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ListItem;


### PR DESCRIPTION
## 📑 구현 사항

- [ ] 공통 컴포넌트 ListItem 구현
위: 내 스테디 목록 페이지의 ListItem
아래: 내 신청서 양식 페이지의 ListItem
<img width="659" alt="image" src="https://github.com/Team-Blitz-Steady/steady-client/assets/109654823/7c12ea38-0a08-43ee-997a-1c9e4dab4923">

- 사용시
```ts
// 임시 data
const steadyInfo = [
  {
    title: "내가 만든 스터디임",
    createdAt: "2023.10.25",
    isAdmin: true,
  },
  {
    title: "참여한 스터디임",
    createdAt: "2023.10.25",
    isAdmin: false,
  },
];

const formInfo = [
  {
    title: "내가 만든 스터디 폼 양식",
    createdAt: "2023.10.25",
    isAdmin: true,
  },
  {
    title: "내가 참여한 스터디 폼 양식",
    createdAt: "2023.10.25",
    isAdmin: false,
  },
];


<ListItem
  object={steadyInfo}
  className="w-1000"
  listType="steady" // steady or from 구분 ( 아이콘 다르게 렌더링)
/>
 
<ListItem
  object={formInfo}
  className="w-750"
  listType="form"
/>
```

## 🚧 특이 사항

- Icon 컴포넌트가 없어서 임시로 사용했습니닷
- Line 컴포넌트가 없어서 임시로 border를 사용했습니다. 
이후 사진 캡쳐후 삭제 했습니다.

## 🚨관련 이슈

#3 