### PR TITLE
✨ Feat: #11 - 공통 컴포넌트 Icon 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,78 +1,8 @@
-import Icon from "@/components/_common/Icon";
-
 const Home = () => {
   return (
     <main>
-      <Icon
-        name="search"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="pencil"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="cross"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="chevron-down"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="eye"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="chat"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="calendar"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="bell"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="gear"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="trash"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="arrow-left"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="chevron-left"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="chevron-right"
-        size={30}
-        color="#000000"
-      />
-      <Icon
-        name="heart"
-        size={30}
-        color="#000000"
-      />
+      <div>This is Main</div>
+      <h1 className="text-3xl font-bold underline">Hello, Steady!</h1>
     </main>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,78 @@
+import Icon from "@/components/_common/Icon";
+
 const Home = () => {
   return (
     <main>
-      <div>This is Main</div>
-      <h1 className="text-3xl font-bold underline">Hello, Steady!</h1>
+      <Icon
+        name="search"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="pencil"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="cross"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="chevron-down"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="eye"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="chat"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="calendar"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="bell"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="gear"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="trash"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="arrow-left"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="chevron-left"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="chevron-right"
+        size={30}
+        color="#000000"
+      />
+      <Icon
+        name="heart"
+        size={30}
+        color="#000000"
+      />
     </main>
   );
 };

--- a/src/components/_common/Icon/index.tsx
+++ b/src/components/_common/Icon/index.tsx
@@ -1,0 +1,159 @@
+import {
+  ArrowLeftIcon,
+  BellIcon,
+  CalendarIcon,
+  ChatBubbleIcon,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  Cross1Icon,
+  EyeOpenIcon,
+  GearIcon,
+  HeartIcon,
+  MagnifyingGlassIcon,
+  Pencil1Icon,
+  TrashIcon,
+} from "@radix-ui/react-icons";
+
+interface IconProps {
+  name: string;
+  size: number;
+  color: string;
+}
+
+const Icon = ({ name = "", size = 5, color = "#000000" }: IconProps) => {
+  let content;
+  switch (name) {
+    case "search":
+      content = (
+        <MagnifyingGlassIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "pencil":
+      content = (
+        <Pencil1Icon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "cross":
+      content = (
+        <Cross1Icon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "chevron-down":
+      content = (
+        <ChevronDownIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "eye":
+      content = (
+        <EyeOpenIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "chat":
+      content = (
+        <ChatBubbleIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "calendar":
+      content = (
+        <CalendarIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "bell":
+      content = (
+        <BellIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "gear":
+      content = (
+        <GearIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "trash":
+      content = (
+        <TrashIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "arrow-left":
+      content = (
+        <ArrowLeftIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "chevron-left":
+      content = (
+        <ChevronLeftIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "chevron-right":
+      content = (
+        <ChevronRightIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "heart":
+      content = (
+        <HeartIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    default:
+      content = "";
+  }
+  return <div>{content}</div>;
+};
+
+export default Icon;

--- a/src/components/_common/Icon/index.tsx
+++ b/src/components/_common/Icon/index.tsx
@@ -12,6 +12,7 @@ import {
   HeartIcon,
   MagnifyingGlassIcon,
   Pencil1Icon,
+  PersonIcon,
   TrashIcon,
 } from "@radix-ui/react-icons";
 
@@ -144,6 +145,15 @@ const Icon = ({ name = "", size = 5, color = "#000000" }: IconProps) => {
     case "heart":
       content = (
         <HeartIcon
+          width={size}
+          height={size}
+          color={color}
+        />
+      );
+      break;
+    case "person":
+      content = (
+        <PersonIcon
           width={size}
           height={size}
           color={color}


### PR DESCRIPTION
## 📑 구현 사항

- [ ] 공통 컴포넌트 Icon 구현

![1](https://github.com/Team-Blitz-Steady/steady-client/assets/61570018/672bc4f2-54ae-429e-a331-17a6dc9c5b77)

- 사용시

![2](https://github.com/Team-Blitz-Steady/steady-client/assets/61570018/d8d63576-cc5e-4d36-96ae-0ede52d97129)

## 🚧 특이 사항
- icon 이름을 일일이 props로 줘야하기 때문에 이름 규칙을 만드는 것도 괜찮을 것 같습니다.


## 🚨관련 이슈

#11 