### PR TITLE
🔨 Refactor(#40): Icon 컴포넌트 적용, width도 조건부 적용

### DIFF
--- a/src/components/_common/ListItem/index.tsx
+++ b/src/components/_common/ListItem/index.tsx
@@ -1,6 +1,6 @@
-import Icon from "@/components/Icon";
 import clsx from "clsx";
 import type { SteadyInfoType } from "@/app/page";
+import Icon from "../Icon";
 
 interface ListItemProps {
   object: SteadyInfoType[];
@@ -16,6 +16,7 @@ const ListItem = ({ className, object, listType }: ListItemProps) => {
           key={id}
           className={clsx(
             "flex h-140 cursor-pointer items-center justify-between px-40 py-50",
+            listType === "steady" ? "w-1000" : "w-750",
             className,
           )}
         >
@@ -29,13 +30,29 @@ const ListItem = ({ className, object, listType }: ListItemProps) => {
                 <>
                   {listType === "steady" ? (
                     <>
-                      <Icon label={"config"} />
-                      <Icon label={"trash"} />
+                      <Icon
+                        name="gear"
+                        size={30}
+                        color="text-st-gray-200"
+                      />
+                      <Icon
+                        name="trash"
+                        size={30}
+                        color="text-st-gray-200"
+                      />
                     </>
                   ) : (
                     <>
-                      <Icon label={"edit"} />
-                      <Icon label={"trash"} />
+                      <Icon
+                        name="pencil"
+                        size={30}
+                        color="text-st-gray-200"
+                      />
+                      <Icon
+                        name="trash"
+                        size={30}
+                        color="text-st-gray-200"
+                      />
                     </>
                   )}
                 </>


### PR DESCRIPTION
## 📑 구현 사항

- [x] Icon 컴포넌트 사용
- [x] listType에 따라 width 조건부로 적용

<img width="1280" alt="image" src="https://github.com/Team-Blitz-Steady/steady-client/assets/109654823/f8b9b5fc-a295-4815-8159-c1140c636aae">


## 🚧 특이 사항
- 사용
```ts
import ListItem from "@/components/_common/ListItem";

const steadyInfo = [
  {
    title: "내가 만든 스터디임",
    createdAt: "2023.10.25",
    isAdmin: true,
  },
  {
    title: "참여한 스터디임",
    createdAt: "2023.10.25",
    isAdmin: false,
  },
];

const formInfo = [
  {
    title: "내가 만든 스터디 폼 양식",
    createdAt: "2023.10.25",
    isAdmin: true,
  },
  {
    title: "내가 참여한 스터디 폼 양식",
    createdAt: "2023.10.25",
    isAdmin: false,
  },
];

export interface SteadyInfoType {
  title: string;
  createdAt: string;
  isAdmin: boolean;
}

const Home = () => {
  return (
    <main>
      <div>This is Main</div>
      <ListItem
        object={steadyInfo}
        listType="steady"
      />

      <h1 className="text-3xl font-bold underline">Hello, Steady!</h1>
      <ListItem
        object={formInfo}
        listType="form"
      />
    </main>
  );
};

export default Home;

```


## 🚨관련 이슈

close #40