### PR TITLE
🚨 Style(#48) Root Layout 공통 스타일 및 헤더 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { Theme } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
+import AppBar from "@/components/_common/AppBar";
 import "./global.css";
 
 const inter = Inter({
@@ -21,7 +22,12 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       className={inter.className}
     >
       <body>
-        <Theme>{children}</Theme>
+        <Theme>
+          <div className={`max-mobile:w-9/10 mx-auto h-screen w-3/4`}>
+            <AppBar isLogin={false} />
+            {children}
+          </div>
+        </Theme>
       </body>
     </html>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,18 +7,22 @@ const px0_1300 = { ...Array.from(Array(1301)).map((_, i) => `${i}px`) };
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
+    screens: {
+      mobile: "450px",
+    },
     colors: {
-      "skyblue-100": "#9dd5ff",
+      "st-skyblue-300": "#9dd5ff",
       "st-primary": "#5585ff",
       "st-red": "#ff5353",
       "st-green": "#35cc00",
-      "st-skyblue": "#ddf1ff",
+      "st-skyblue-50": "#ddf1ff",
       "st-gray-50": "#f5f5f5",
       "st-gray-100": "#b4b4b4",
       "st-gray-200": "#8a8a8a",
       "st-gray-250": "#858585",
       "st-gray-400": "#6c6c6c",
-      "input-bg": "#f8f8f8",
+      "st-white": "#ffffff",
+      "st-white-50": "#f8f8f8",
     },
     extend: {
       width: px0_1300,


### PR DESCRIPTION
## 📑 구현 사항

- [ ] 페이지 전역적으로 적용되는 Root Layout의 좌우 여백 스타일을 추가했습니다
- [ ] 헤더를 루트 레이아웃에 포함시켰습니다

![Oct-27-2023 17-09-28](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/252a64fd-5b85-4a79-bdf8-c28e9317c306)


## 🚧 특이 사항

- 현재 헤더가 일정 너비 이상에서 로고와 버튼 사이 간격이 고정되는 스타일이 빠져있는데, 나중에 추가하도록 하겠습니다!


## 🚨관련 이슈

close #48 