### PR TITLE
🚨 Fix(#55): Avatar 컴포넌트 에러 수정 외 1건

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/themes": "^2.0.0",
     "@tanstack/react-query": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@radix-ui/react-avatar':
+    specifier: ^1.0.4
+    version: 1.0.4(@types/react-dom@18.0.0)(@types/react@18.0.0)(react-dom@18.0.0)(react@18.0.0)
   '@radix-ui/react-icons':
     specifier: ^1.3.0
     version: 1.3.0(react@18.0.0)

--- a/src/components/_common/Avatar/index.tsx
+++ b/src/components/_common/Avatar/index.tsx
@@ -1,19 +1,25 @@
-import Image from "next/image";
+"use client";
+
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
 
 interface AvatarProps {
   src: string;
+  alt?: string;
   size: number;
 }
 
-const Avatar = ({ src, size }: AvatarProps) => {
+const Avatar = ({ src, alt = "S", size }: AvatarProps) => {
   return (
-    <Image
-      className={"rounded-full"}
-      src={src}
-      alt={"S"}
-      width={size}
-      height={size}
-    />
+    <AvatarPrimitive.Root
+      className={`inline-flex h-[${size}px] w-[${size}px] select-none items-center justify-center overflow-hidden rounded-full align-middle`}
+    >
+      <AvatarPrimitive.Image
+        className={"h-full w-full rounded-[inherit] object-cover"}
+        src={src}
+        alt={alt}
+      />
+      <AvatarPrimitive.AvatarFallback>{alt}</AvatarPrimitive.AvatarFallback>
+    </AvatarPrimitive.Root>
   );
 };
 


### PR DESCRIPTION
## 📑 구현 사항

- [x] 가로 세로 비율이 동일하지 않은 이미지 src 추가 시 rounded-full 스타일이 적용되지 않았던 문제 수정

ex) 이런 이미지를 Avatar src로 등록해도
<img width="641" alt="ci" src="https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/15177652-8543-49dc-a02e-4b97daed728f">
<img width="256" alt="스크린샷 2023-10-29 오후 3 25 15" src="https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/d1ed2c4d-8d65-412e-827c-e97755de97f3">
위와 같이 원형으로 구현됨

- [x] alt를 prop으로 받을 수 있도록 변경
- [x] 현재 alt 값을 Fallback UI로 보여주는 중

```jsx
<Avatar
  src={"/images/c1.png"} // 올바른 경로는 /images/ci.png
  size={80}
  alt={"S"}
/>
```
<img width="271" alt="스크린샷 2023-10-29 오후 3 26 38" src="https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/467a9cf9-ac98-42e2-bcd5-24709ca649f9">

위와 같이 prop value를 보여줌


## 🚧 특이 사항

- Next Image 컴포넌트를 Radix UI의 AvatarPrimitive의 자식으로 넘기려 했는데 원형 유지가 안되는 문제가 있어서 해당 아이디어 폐기
- 따라서 현재는 Next Image 컴포넌트를 활용하고 있지 않음


## 🚨관련 이슈

close #55