### PR TITLE
✨ Feat(#88): HashTagInput 컴포넌트 추가

### DIFF
--- a/src/components/_common/HashTagInput/index.tsx
+++ b/src/components/_common/HashTagInput/index.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import type { KeyboardEvent } from "react";
+import { useCallback, useRef, useState } from "react";
+import * as React from "react";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import { Cross2Icon } from "@radix-ui/react-icons";
+import { Badge } from "@radix-ui/themes";
+import { Command } from "cmdk";
+
+interface HashTagInputProps {
+  placeholder?: string;
+  tagSize?: "1" | "2";
+  initialData?: string[];
+  className?: string;
+}
+
+const HashTagInput = ({
+  placeholder,
+  initialData,
+  tagSize = "1",
+  className,
+}: HashTagInputProps) => {
+  const [tags, setTags] = useState<string[]>(initialData || []);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [inputValue, setInputValue] = useState("");
+  const { toast } = useToast();
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      const input = inputRef.current;
+      if (input) {
+        if (event.key === "Delete" || event.key === "Backspace") {
+          if (input.value === "") {
+            setTags((prev) => {
+              const prevTags = [...prev];
+              prevTags.pop();
+              return prevTags;
+            });
+          }
+        }
+        if (event.key === "Escape") {
+          input.blur();
+        }
+      }
+    },
+    [setTags],
+  );
+
+  const handleAddHashTag = useCallback(() => {
+    if (inputValue === "") {
+      (() => {
+        toast({ description: "태그를 입력해주세요!", variant: "red" });
+      })();
+      return;
+    }
+    if (tags.includes(inputValue)) {
+      (() => {
+        toast({
+          description: "이미 추가된 태그입니다!",
+          variant: "red",
+        });
+      })();
+      return;
+    }
+    setTags((prev) => {
+      const newTags = [...prev];
+      newTags.push(inputValue);
+      setInputValue("");
+      return newTags;
+    });
+  }, [inputValue, toast, tags, setTags]);
+
+  const handleDeleteHashTag = useCallback(
+    (tag: string) => {
+      setTags((prev) => prev.filter((item) => item !== tag));
+    },
+    [setTags],
+  );
+  return (
+    <Command onKeyDown={handleKeyDown}>
+      <div className={cn("flex flex-row items-center", className)}>
+        <div>
+          {tags.map((tag, idx) => {
+            return (
+              <Badge
+                className={cn("mr-5")}
+                key={idx}
+                size={tagSize}
+                variant="soft"
+              >
+                {`# ${tag}`}
+                <button
+                  className={cn("")}
+                  onClick={() => handleDeleteHashTag(tag)}
+                >
+                  <Cross2Icon className="ml-4 h-12 w-12 text-muted-foreground hover:text-foreground" />
+                </button>
+              </Badge>
+            );
+          })}
+        </div>
+        {tags.length < 5 && (
+          <Command.Input
+            ref={inputRef}
+            className={cn(
+              "group flex h-40 flex-row items-center justify-between rounded-md border border-input px-10 py-4 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+              className,
+            )}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                handleAddHashTag();
+              }
+            }}
+            onValueChange={setInputValue}
+            value={inputValue}
+            placeholder={placeholder}
+          />
+        )}
+      </div>
+    </Command>
+  );
+};
+
+export default HashTagInput;

--- a/src/components/_common/HashTagInput/index.tsx
+++ b/src/components/_common/HashTagInput/index.tsx
@@ -109,6 +109,9 @@ const HashTagInput = ({
               className,
             )}
             onKeyDown={(event) => {
+              if (event.nativeEvent.isComposing) {
+                return;
+              }
               if (event.key === "Enter") {
                 handleAddHashTag();
               }

--- a/src/components/_common/HashTagInput/index.tsx
+++ b/src/components/_common/HashTagInput/index.tsx
@@ -17,7 +17,7 @@ interface HashTagInputProps {
 }
 
 const HashTagInput = ({
-  placeholder,
+  placeholder = "해쉬 태그를 입력해주세요!",
   initialData,
   tagSize = "1",
   className,

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -13,7 +13,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-16 sm:right-0 sm:top-0 sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-16 sm:right-0 sm:top-0 sm:flex-col md:max-h-100 md:max-w-[300px]",
       className,
     )}
     {...props}
@@ -26,9 +26,12 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
-        destructive:
+        default: cn("border bg-st-white text-foreground"),
+        blue: cn("border bg-st-primary text-st-white"),
+        green: cn("border bg-st-green text-st-white"),
+        red: cn(
           "destructive group border-destructive bg-destructive text-destructive-foreground",
+        ),
       },
     },
     defaultVariants: {
@@ -103,7 +106,7 @@ const ToastDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
-    className={cn("text-sm opacity-90", className)}
+    className={cn("text-md opacity-90", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## 📑 구현 사항

- [ ] 해쉬태그 입력을 간편하게 할 수 있는 HashTagInput 컴포넌트를 만들었습니다!
- [ ] 토스트 메시지의 variant를 추가해서 더 다양한 상황에 대응할 수 있도록 만들었습니다! (red, green, blue)
![Nov-03-2023 17-47-36](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/ac5a9e90-bae7-42c7-9a21-7302ccfb69b2)

![Nov-03-2023 17-47-42](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/819c11fb-83f4-4db3-9711-23c7531c0ade)


## 🚧 특이 사항

- [ ] 해쉬태그는 5개까지 입력할 수 있도록 만들었습니다!
- [ ] placeholder, initialData, className, tagSize를 Prop으로 받을 수 있습니다!


## 🚨관련 이슈

close #88