### PR TITLE
✨ Feat(#117): Query Client 생성 및 Provider 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { Toaster } from "@/components/ui/toaster";
+import QueryProvider from "@/lib/react-query/QueryProvider";
 import { cn } from "@/lib/utils";
 import { Theme } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
@@ -20,25 +21,27 @@ export const metadata: Metadata = {
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <html
-      lang="ko"
-      className={inter.className}
-    >
-      <body className="h-screen">
-        <Theme>
-          <div
-            className={cn(
-              `max-mobile:w-9/10 mx-auto flex w-3/4 flex-col items-center`,
-            )}
-          >
-            <AppBar isLogin={false} />
-            <div className={cn("my-30")}>{children}</div>
-            <Footer />
-          </div>
-        </Theme>
-        <Toaster />
-      </body>
-    </html>
+    <QueryProvider>
+      <html
+        lang="ko"
+        className={inter.className}
+      >
+        <body className="h-screen">
+          <Theme>
+            <div
+              className={cn(
+                `max-mobile:w-9/10 mx-auto flex w-3/4 flex-col items-center`,
+              )}
+            >
+              <AppBar isLogin={false} />
+              <div className={cn("my-30")}>{children}</div>
+              <Footer />
+            </div>
+          </Theme>
+          <Toaster />
+        </body>
+      </html>
+    </QueryProvider>
   );
 };
 

--- a/src/lib/react-query/QueryProvider.tsx
+++ b/src/lib/react-query/QueryProvider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+
+const QueryProvider = ({ children }: { children: ReactNode }) => {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+export default QueryProvider;


### PR DESCRIPTION
## 📑 구현 사항

- [ ] 페이지 전역적으로 React-Query를 사용할 수 있도록 Provider를 RootLayout에 감싸주었습니다!


## 🚧 특이 사항

- useQuery 훅을 사용하는 컴포넌트는 클라이언트 컴포넌트여야합니다!
- 예제 코드 : client/page.tsx
```tsx
"use client";

import { useQuery } from "@tanstack/react-query";
import axios from "axios";

interface TodoType {
  userId: number;
  id: number;
  title: string;
  completed: boolean;
}

const ClientPage = () => {
  const { data, isPending, error } = useQuery<{ data: TodoType[] }>({
    queryKey: ["todos"],
    queryFn: () => axios.get("https://jsonplaceholder.typicode.com/todos"),
  });
  if (isPending) {
    return <div>loading...</div>;
  }
  if (error) {
    return <div>Error! {error.message}</div>;
  }
  return (
    <div>
      {data.data.map((todo) => (
        <div key={todo.id}>{todo.title}</div>
      ))}
    </div>
  );
};

export default ClientPage;

```

<img width="943" alt="스크린샷 2023-11-07 오전 11 49 41" src="https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/c8e87ae2-3623-49b4-8215-e776d6134443">



## 🚨관련 이슈

close #117 