### PR TITLE
✨ Feat(#126): 스테디 상세 페이지 api 연동 

### DIFF
--- a/src/app/(steady)/steady/detail/[id]/page.tsx
+++ b/src/app/(steady)/steady/detail/[id]/page.tsx
@@ -84,7 +84,7 @@ const SteadyDetailPage = ({ params }: { params: PageParams }) => {
 
         <div className="flex flex-row items-center justify-between">
           <div className="flex flex-row items-center justify-center gap-20">
-            <Tag status={steadyDetailsData?.status} />
+            {steadyDetailsData && <Tag status={steadyDetailsData.status} />}
             <div className="text-35 font-bold">{Announcement.title}</div>
           </div>
           {/* TODO: 좋아요 API 연결 */}

--- a/src/app/(steady)/steady/detail/[id]/page.tsx
+++ b/src/app/(steady)/steady/detail/[id]/page.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Avatar, Separator, TextArea } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
+import getSteadyDetails from "@/services/steady/getSteadyDetails";
 import Button, { buttonSize } from "@/components/_common/Button";
 import Icon from "@/components/_common/Icon";
 import { AlertModal, UserModal } from "@/components/_common/Modal";
@@ -63,6 +65,10 @@ interface PageParams {
 }
 
 const SteadyDetailPage = ({ params }: { params: PageParams }) => {
+  const { data: steadyDetailsData } = useQuery({
+    queryKey: ["steadyDetails"],
+    queryFn: () => getSteadyDetails(params.id),
+  });
   const router = useRouter();
   console.log(params);
   return (
@@ -78,7 +84,7 @@ const SteadyDetailPage = ({ params }: { params: PageParams }) => {
 
         <div className="flex flex-row items-center justify-between">
           <div className="flex flex-row items-center justify-center gap-20">
-            <Tag status={SteadyPrimitive.status} />
+            <Tag status={steadyDetailsData?.status} />
             <div className="text-35 font-bold">{Announcement.title}</div>
           </div>
           {/* TODO: 좋아요 API 연결 */}

--- a/src/components/Posts/index.tsx
+++ b/src/components/Posts/index.tsx
@@ -1,6 +1,7 @@
 import { Avatar } from "@radix-ui/themes";
 import Icon from "../_common/Icon";
-import Tag from "../_common/Tag";
+
+// import Tag from "../_common/Tag";
 
 interface PostData {
   title: string;
@@ -24,7 +25,7 @@ const Posts = ({ info }: { info?: PostData[] }) => {
             className="flex w-full items-center justify-between px-50 py-20 transition hover:scale-105 hover:bg-st-gray-50"
           >
             <div className="flex items-center gap-50">
-              <Tag status="모집" />
+              {/* <Tag status="모집" /> */}
               <div className="flex flex-col gap-5">
                 <div className="font-bold">📖스터디</div>
                 <div className="text-25 font-bold">{item.title}</div>

--- a/src/components/_common/Tag/index.tsx
+++ b/src/components/_common/Tag/index.tsx
@@ -1,15 +1,21 @@
 interface TagProps {
-  status: string;
+  status: "RECRUITING" | "CLOSED" | "FINISHED";
 }
+
+const STATUS = {
+  RECRUITING: "모집중",
+  CLOSED: "마감",
+  FINISHED: "종료",
+};
 
 const Tag = ({ status, ...props }: TagProps) => {
   return (
     <div
-      className="h-40 w-80 rounded-50 bg-st-primary p-5"
+      className="flex h-40 w-80 items-center justify-center rounded-50 bg-st-primary p-5"
       {...props}
     >
-      <div className="max-mobile:text-15 h-full w-full rounded-50 bg-st-white text-center text-20 font-bold">
-        {status === "모집" ? "모집" : "마감"}
+      <div className="max-mobile:text-13 flex h-full w-full items-center justify-center rounded-50 bg-st-white text-16 font-bold">
+        {STATUS[status]}
       </div>
     </div>
   );

--- a/src/services/steady/getSteadyDetails.ts
+++ b/src/services/steady/getSteadyDetails.ts
@@ -2,7 +2,7 @@ import { axiosInstance } from "@/services";
 import type { AxiosResponse } from "axios";
 import type { SteadyDetailsType } from "../types";
 
-const getSteadyDetails = async (steadyId: number) => {
+const getSteadyDetails = async (steadyId: string) => {
   try {
     const response: AxiosResponse<SteadyDetailsType> = await axiosInstance.get(
       `/api/v1/steadies/${steadyId}`,

--- a/src/services/steady/getSteadyDetails.ts
+++ b/src/services/steady/getSteadyDetails.ts
@@ -8,7 +8,7 @@ const getSteadyDetails = async (steadyId: string) => {
       `/api/v1/steadies/${steadyId}`,
     );
     if (Math.floor(response.status / 10) !== 20) {
-      throw new Error("Failed to fetch steady detail url!");
+      throw new Error("Failed to fetch steady detail!");
     }
     return response.data;
   } catch (error) {

--- a/src/services/steady/getSteadyDetails.ts
+++ b/src/services/steady/getSteadyDetails.ts
@@ -1,55 +1,6 @@
 import { axiosInstance } from "@/services";
 import type { AxiosResponse } from "axios";
-
-interface LeaderResponse {
-  id: number;
-  nickname: string;
-  profileImage: string;
-}
-
-interface Position {
-  id: number;
-  name: string;
-}
-
-interface Stack {
-  id: number;
-  name: string;
-  imageUrl: string;
-}
-
-interface SteadyDetailsType {
-  id: number;
-  leaderResponse: LeaderResponse;
-  name: string;
-  bio: string;
-  type: "STUDY" | "PROJECT";
-  status: "RECRUITING" | "CLOSED" | "FINISHED";
-  participantLimit: number;
-  numberOfParticipants: number;
-  steadyMode: "ONLINE" | "OFFLINE" | "BOTH";
-  scheduledPeriod:
-    | "TO_BE_DETERMINED"
-    | "ONE_WEEK"
-    | "TWO_WEEK"
-    | "THREE_WEEK"
-    | "FOUR_WEEK"
-    | "FIVE_WEEK"
-    | "TWO_MONTH"
-    | "THREE_MONTH"
-    | "FOUR_MONTH"
-    | "FIVE_MONTH"
-    | "SIX_MONTH"
-    | "LONG_TERM";
-  deadline: string;
-  title: string;
-  content: string;
-  positions: Position[];
-  stacks: Stack[];
-  isLeader: boolean;
-  isSubmittedUser: boolean;
-  promotionCount: number;
-}
+import type { SteadyDetailsType } from "../types";
 
 const getSteadyDetails = async (steadyId: number) => {
   try {

--- a/src/services/steady/getSteadyDetails.ts
+++ b/src/services/steady/getSteadyDetails.ts
@@ -1,0 +1,69 @@
+import { axiosInstance } from "@/services";
+import type { AxiosResponse } from "axios";
+
+interface LeaderResponse {
+  id: number;
+  nickname: string;
+  profileImage: string;
+}
+
+interface Position {
+  id: number;
+  name: string;
+}
+
+interface Stack {
+  id: number;
+  name: string;
+  imageUrl: string;
+}
+
+interface SteadyDetailsType {
+  id: number;
+  leaderResponse: LeaderResponse;
+  name: string;
+  bio: string;
+  type: "STUDY" | "PROJECT";
+  status: "RECRUITING" | "CLOSED" | "FINISHED";
+  participantLimit: number;
+  numberOfParticipants: number;
+  steadyMode: "ONLINE" | "OFFLINE" | "BOTH";
+  scheduledPeriod:
+    | "TO_BE_DETERMINED"
+    | "ONE_WEEK"
+    | "TWO_WEEK"
+    | "THREE_WEEK"
+    | "FOUR_WEEK"
+    | "FIVE_WEEK"
+    | "TWO_MONTH"
+    | "THREE_MONTH"
+    | "FOUR_MONTH"
+    | "FIVE_MONTH"
+    | "SIX_MONTH"
+    | "LONG_TERM";
+  deadline: string;
+  title: string;
+  content: string;
+  positions: Position[];
+  stacks: Stack[];
+  isLeader: boolean;
+  isSubmittedUser: boolean;
+  promotionCount: number;
+}
+
+const getSteadyDetails = async (steadyId: number) => {
+  try {
+    const response: AxiosResponse<SteadyDetailsType> = await axiosInstance.get(
+      `/api/v1/steadies/${steadyId}`,
+    );
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to fetch steady detail url!");
+    }
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw Error;
+  }
+};
+
+export default getSteadyDetails;

--- a/src/services/steady/getSteadyDetails.ts
+++ b/src/services/steady/getSteadyDetails.ts
@@ -8,7 +8,7 @@ const getSteadyDetails = async (steadyId: string) => {
       `/api/v1/steadies/${steadyId}`,
     );
     if (Math.floor(response.status / 10) !== 20) {
-      throw new Error("Failed to fetch steady detail!");
+      throw new Error("Failed to fetch steady detail api!");
     }
     return response.data;
   } catch (error) {

--- a/src/services/steady/getSteadyDetails.ts
+++ b/src/services/steady/getSteadyDetails.ts
@@ -13,7 +13,7 @@ const getSteadyDetails = async (steadyId: string) => {
     return response.data;
   } catch (error) {
     console.error(error);
-    throw Error;
+    throw error;
   }
 };
 

--- a/src/services/types/index.ts
+++ b/src/services/types/index.ts
@@ -6,3 +6,53 @@ export interface KakaoTokenType {
     refreshToken: string;
   };
 }
+
+export interface LeaderResponseType {
+  id: number;
+  nickname: string;
+  profileImage: string;
+}
+
+export interface PositionType {
+  id: number;
+  name: string;
+}
+
+export interface StackType {
+  id: number;
+  name: string;
+  imageUrl: string;
+}
+
+export interface SteadyDetailsType {
+  id: number;
+  leaderResponse: LeaderResponseType;
+  name: string;
+  bio: string;
+  type: "STUDY" | "PROJECT";
+  status: "RECRUITING" | "CLOSED" | "FINISHED";
+  participantLimit: number;
+  numberOfParticipants: number;
+  steadyMode: "ONLINE" | "OFFLINE" | "BOTH";
+  scheduledPeriod:
+    | "TO_BE_DETERMINED"
+    | "ONE_WEEK"
+    | "TWO_WEEK"
+    | "THREE_WEEK"
+    | "FOUR_WEEK"
+    | "FIVE_WEEK"
+    | "TWO_MONTH"
+    | "THREE_MONTH"
+    | "FOUR_MONTH"
+    | "FIVE_MONTH"
+    | "SIX_MONTH"
+    | "LONG_TERM";
+  deadline: string;
+  title: string;
+  content: string;
+  positions: PositionType[];
+  stacks: StackType[];
+  isLeader: boolean;
+  isSubmittedUser: boolean;
+  promotionCount: number;
+}


### PR DESCRIPTION
## 📑 구현 사항

- [x] steady details api 연동
- [x] Tag 컴포넌트 모집중, 마감, 종료 3가지 상태로 받을 수 있도록 수정


## 🚧 특이 사항

- 상세 페이지에서 useQuery로 `getSteadyDetails` 사용시
```ts
const { data: steadyDetailsData } = useQuery({
    queryKey: ["steadyDetails"],
    queryFn: () => getSteadyDetails(params.id),
  });

 {steadyDetailsData && <Tag status={steadyDetailsData.status} />}
```

<img width="76" alt="image" src="https://github.com/Team-Blitz-Steady/steady-client/assets/109654823/2e97ad46-956b-42bf-8569-dcdc50fe2495">


## 🚨관련 이슈

close #126