### PR TITLE
✨ Feat(#128): 스테디 종료 api 연동

### DIFF
--- a/src/services/steady/finishSteady.ts
+++ b/src/services/steady/finishSteady.ts
@@ -6,7 +6,7 @@ const finishSteady = async (steadyId: string) => {
       `/api/v1/steadies/${steadyId}/finish`,
     );
     if (Math.floor(response.status / 10) !== 20) {
-      throw new Error("Failed to fetch finish steady url!");
+      throw new Error("Failed to fetch finish steady api!");
     }
     return response;
   } catch (error) {

--- a/src/services/steady/finishSteady.ts
+++ b/src/services/steady/finishSteady.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from "..";
+
+const finishSteady = async (steadyId: string) => {
+  try {
+    const response = await axiosInstance.patch(
+      `/api/v1/steadies/${steadyId}/finish`,
+    );
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to fetch finish steady url!");
+    }
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default finishSteady;


### PR DESCRIPTION
## 📑 구현 사항

- [x] 스테디 종료 api 연동

<img width="512" alt="image" src="https://github.com/Team-Blitz-Steady/steady-client/assets/109654823/4b0b80ea-daeb-4b02-b6eb-8052dd4e06f1">

## 🚧 특이 사항

- 사용예시
```ts
// params.id는 스테디 id 입니다.
 <button onClick={() => finishSteady(params.id)}>스테디 종료</button>
```


## 🚨관련 이슈

close #128