### PR TITLE
✨ Feat(#129): 스테디 끌어올리기 api 연동

### DIFF
--- a/src/services/steady/promoteSteady.ts
+++ b/src/services/steady/promoteSteady.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from "..";
+
+const promoteSteady = async (steadyId: string) => {
+  try {
+    const response = await axiosInstance.patch(
+      `/api/v1/steadies/${steadyId}/promote`,
+    );
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to fetch promote steady api!");
+    }
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default promoteSteady;


### PR DESCRIPTION
## 📑 구현 사항

- [x] 스테디 끌어올리기 api 연동

<img width="400" alt="image" src="https://github.com/Team-Blitz-Steady/steady-client/assets/109654823/0503838b-9688-480a-b459-6d5855fee7af">



## 🚧 특이 사항

- 현재 promoteSteady api는 호출 할 때마다 끌어올리기 횟수가 차감되도록 백엔드 쪽에 구현되어있는 것 같습니다.
- 따라서 프론트 쪽에서 스테디 상세 정보 받아올 때, validation이 필요할 것 같습니다. (0 이면 더 이상 누르지 못하도록)


- 사용예시
```ts
// params.id는 스테디 id
<button onClick={() => promoteSteady(params.id)}>끌어올리기</button>
```


## 🚨관련 이슈

close #129