### PR TITLE
✨Feat(#144): 신청서 상세 조회 api 연동

### DIFF
--- a/src/app/(steady)/steady/applicant/[id]/page.tsx
+++ b/src/app/(steady)/steady/applicant/[id]/page.tsx
@@ -1,36 +1,25 @@
 "use client";
 
 import { Question } from "@/components/application";
-
-const Application = {
-  id: "2", // 신청서 ID
-  item: [
-    {
-      question: "당신의 이름은?",
-      answer: "지윤",
-    },
-    {
-      question: "당신의 나이는?",
-      answer: "14",
-    },
-    {
-      question: "당신의 성별은?",
-      answer: "여",
-    },
-  ],
-};
+import { useQuery } from "@tanstack/react-query";
+import getApplicationDetails from "@/services/application/getApplicationDetails";
 
 const ApplicantPage = () => {
+  // TODO: 12를 applicationId로 변경해야 함
+  const { data: applicationDetailsData } = useQuery({
+    queryKey: ["applicationDetails"],
+    queryFn: () => getApplicationDetails("12"),
+  });
   return (
     <div className="flex w-full flex-col gap-10">
-      {Application.item.map((item, id) => (
+      {applicationDetailsData?.surveys.map(({ question, answer }, id) => (
         <Question
           key={id}
-          question={item.question}
+          question={question}
           index={id}
         >
           <div className="h-100 w-full border-1 border-st-gray-100">
-            {item.answer}
+            {answer}
           </div>
         </Question>
       ))}

--- a/src/services/application/getApplicationDetails.ts
+++ b/src/services/application/getApplicationDetails.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from "@/services";
+import type { AxiosResponse } from "axios";
+import type { ApplicationDetailsType } from "../types";
+
+const getApplicationDetails = async (applicationId: string) => {
+  try {
+    const response: AxiosResponse<ApplicationDetailsType> =
+      await axiosInstance.get(`/api/v1/applications/${applicationId}`);
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to fetch application detail api!");
+    }
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default getApplicationDetails;

--- a/src/services/types/index.ts
+++ b/src/services/types/index.ts
@@ -56,3 +56,12 @@ export interface SteadyDetailsType {
   isSubmittedUser: boolean;
   promotionCount: number;
 }
+
+export interface ApplicationSurveyType {
+  question: string;
+  answer: string;
+}
+
+export interface ApplicationDetailsType {
+  surveys: ApplicationSurveyType[];
+}


### PR DESCRIPTION
## 📑 구현 사항

- [x] 신청서 상세 조회 api 연동

- postman
<img width="506" alt="image" src="https://github.com/Team-Blitz-Steady/steady-client/assets/109654823/38204eb0-460d-4e80-9392-f5688d7fdc23">

- 신청자 목록 및 답변 열람 페이지 & Network 요청
<img width="1276" alt="image" src="https://github.com/Team-Blitz-Steady/steady-client/assets/109654823/f54c53b0-f298-4a89-bc8d-96cd889616a2">


## 🚧 특이 사항


## 🚨관련 이슈

close #144