### PR TITLE
✨ Feat(#167): 스테디 생성 페이지에 기술 스택, 모집 분야 요청 API 적용

### DIFF
--- a/src/app/(steady)/steady/create/loading.tsx
+++ b/src/app/(steady)/steady/create/loading.tsx
@@ -1,0 +1,9 @@
+const CreateLoading = () => {
+  return (
+    <div>
+      <h1>loading...</h1>
+    </div>
+  );
+};
+
+export default CreateLoading;

--- a/src/services/steady/getPositions.ts
+++ b/src/services/steady/getPositions.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+import type { PositionResponse } from "@/services/types";
+
+const getPositions = async () => {
+  // TODO: Axios 인터셉터 오류 해결 시 대체
+  try {
+    const response = await axios.get<PositionResponse>(
+      "https://dev.steadies.kr/api/v1/positions",
+    );
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to fetch positions api!");
+    }
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default getPositions;

--- a/src/services/steady/getStacks.ts
+++ b/src/services/steady/getStacks.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+import type { StackResponse } from "@/services/types";
+
+const getStacks = async () => {
+  // TODO: Axios 인터셉터 오류 해결 시 대체
+  try {
+    const response = await axios.get<StackResponse>(
+      "https://dev.steadies.kr/api/v1/stacks",
+    );
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to fetch stacks api!");
+    }
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default getStacks;

--- a/src/services/types/index.ts
+++ b/src/services/types/index.ts
@@ -165,3 +165,10 @@ export interface CheckSameUsernameType {
 export interface ApplicationStatusType {
   status: "ACCEPTED" | "WAITING" | "REJECTED";
 }
+export interface StackResponse {
+  stacks: StackType[];
+}
+
+export interface PositionResponse {
+  positions: PositionType[];
+}


### PR DESCRIPTION
## 📑 구현 사항

- [x] 스테디 생성 페이지에 기술 스택 정보 요청 API 적용
- [x] 스테디 생성 페이지에 모집 분야 정보 요청 API 적용

![Nov-14-2023 17-43-00](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/537da460-0320-4533-86c9-7c23139c24a7)


## 🚧 특이 사항

- [x] 일단 Axios 인터셉터 관련 오류가 있어서 일반 axios 요청을 보냈고(토큰을 요구하는 요청이 아니라 일단 잘 작동합니다) 
- 해당 내용 TODO 주석으로 남겼습니다


## 🚨관련 이슈

close #167 