### PR TITLE
✨ Feat(#176): 스테디 질문 수정 페이지 api 연동

### DIFF
--- a/src/app/(steady)/steady/edit/[id]/page.tsx
+++ b/src/app/(steady)/steady/edit/[id]/page.tsx
@@ -119,7 +119,7 @@ const SteadyEditPage = ({
 
   const onSubmit = async (data: SteadyEditStateType) => {
     updateSteady(id, data).then((res) => {
-      if (res?.status === 204) {
+      if (res.status === 204) {
         toast({ variant: "green", description: "스테디가 수정되었습니다!" });
         router.push(`/steady/detail/${id}`);
       } else {

--- a/src/app/(steady)/steady/edit/questions/[id]/loading.tsx
+++ b/src/app/(steady)/steady/edit/questions/[id]/loading.tsx
@@ -1,0 +1,9 @@
+const LoadingQuestions = () => {
+  return (
+    <div>
+      <h2>Loading Questions...</h2>
+    </div>
+  );
+};
+
+export default LoadingQuestions;

--- a/src/app/(steady)/steady/edit/questions/[id]/page.tsx
+++ b/src/app/(steady)/steady/edit/questions/[id]/page.tsx
@@ -15,7 +15,11 @@ import Icon from "@/components/_common/Icon";
 import { SingleSelector } from "@/components/_common/Selector";
 
 const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
-  const { data: questionsData, error } = useSuspenseQuery({
+  const {
+    data: questionsData,
+    error,
+    refetch: refetchQuestions,
+  } = useSuspenseQuery({
     queryKey: ["questions"],
     queryFn: () => getSteadyQuestions(params.id),
   });
@@ -70,6 +74,7 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
     const questionData = question.map((item) => item.question);
     updateSteadyQuestions(params.id, questionData).then((res) => {
       if (res.status === 204) {
+        refetchQuestions();
         toast({
           description: "질문이 수정되었습니다.",
           variant: "green",

--- a/src/app/(steady)/steady/edit/questions/[id]/page.tsx
+++ b/src/app/(steady)/steady/edit/questions/[id]/page.tsx
@@ -79,7 +79,7 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
           description: "질문이 수정되었습니다.",
           variant: "green",
         });
-        router.push(`/steady/detail/${params.id}/`);
+        router.replace(`/steady/detail/${params.id}/`);
       } else {
         toast({
           description: "질문 수정에 실패했습니다.",
@@ -184,7 +184,12 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
         className={cn("h-5 bg-st-gray-400")}
       />
       <div className={"flex justify-end gap-20"}>
-        <Button className={cn(`${buttonSize.sm} items-center justify-center`)}>
+        <Button
+          className={cn(`${buttonSize.sm} items-center justify-center`)}
+          onClick={() => {
+            router.back();
+          }}
+        >
           취소
         </Button>
         <Button

--- a/src/services/steady/getSteadyQuestions.ts
+++ b/src/services/steady/getSteadyQuestions.ts
@@ -1,0 +1,23 @@
+import { axiosInstance } from "@/services";
+import type { AxiosResponse } from "axios";
+import type { SteadyQuestionsType } from "@/services/types";
+
+const getSteadyQuestions = async (steadyId: string) => {
+  try {
+    const response: AxiosResponse<SteadyQuestionsType> =
+      await axiosInstance.get<SteadyQuestionsType>(
+        `/api/v1/steadies/${steadyId}/questions`,
+      );
+
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to fetch steady questions!");
+    }
+
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default getSteadyQuestions;

--- a/src/services/steady/updateSteady.ts
+++ b/src/services/steady/updateSteady.ts
@@ -10,6 +10,7 @@ const updateSteady = async (steadyId: number, data: SteadyEditStateType) => {
     return res;
   } catch (error) {
     console.error(error);
+    throw error;
   }
 };
 

--- a/src/services/steady/updateSteadyQuestions.ts
+++ b/src/services/steady/updateSteadyQuestions.ts
@@ -1,0 +1,21 @@
+import { axiosInstance } from "@/services";
+
+const updateSteadyQuestions = async (steadyId: string, questions: string[]) => {
+  try {
+    const response = await axiosInstance.patch(
+      `/api/v1/steadies/${steadyId}/questions`,
+      {
+        questions: questions,
+      },
+    );
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to update steady questions!");
+    }
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default updateSteadyQuestions;

--- a/src/services/types/index.ts
+++ b/src/services/types/index.ts
@@ -187,3 +187,13 @@ export interface StackResponse {
 export interface PositionResponse {
   positions: PositionType[];
 }
+
+export interface SteadyQuestionsType {
+  steadyQuestions: [
+    {
+      id: number;
+      content: string;
+      sequence: number;
+    },
+  ];
+}


### PR DESCRIPTION
## 📑 구현 사항

- [x] 스테디 질문 조회 api 요청 함수와 타입을 추가했습니다!
- [x] 스테디 질문 수정 api 요청 함수를 추가했습니다!
- [x] 스테디 질문 수정 페이지에 api를 연동했습니다!
    - 질문 수정에 성공하면 해당 스테디의 모집글 상세 페이지로 이동합니다!

![Nov-16-2023 09-18-21](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/2a884526-df95-4d7c-a46c-55e80d3bd021)


## 🚧 특이 사항

- 딱히 없습니다! 질문 수정이 어제 새벽엔 안되던데 오늘 아침에 되니까 신기하네요..


## 🚨관련 이슈

close #176 