### PR TITLE
✨ Feat(#175): 상세 페이지에 신청서 보기 API 연동

### DIFF
--- a/src/app/(steady)/steady/detail/[id]/page.tsx
+++ b/src/app/(steady)/steady/detail/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import getSteadyDetails from "@/services/steady/getSteadyDetails";
 import getSteadyParticipants from "@/services/steady/getSteadyParticipants";
+import getSteadyQuestions from "@/services/steady/getSteadyQuestions";
 import promoteSteady from "@/services/steady/promoteSteady";
 import type { SteadyDetailsType } from "@/services/types";
 import Button, { buttonSize } from "@/components/_common/Button";
@@ -38,6 +39,11 @@ const SteadyDetailPage = ({ params }: { params: PageParams }) => {
     queryKey: ["steadyParticipants"],
     queryFn: () => getSteadyParticipants(params.id),
   });
+  const { data: steadyQuestionsData } = useSuspenseQuery({
+    queryKey: ["steadyQuestions"],
+    queryFn: () => getSteadyQuestions(params.id),
+  });
+
   const router = useRouter();
   const { toast } = useToast();
 
@@ -225,10 +231,26 @@ const SteadyDetailPage = ({ params }: { params: PageParams }) => {
         </div>
         <div className="text-35 font-bold ">{steadyDetailsData.title}</div>
         <div className="mb-10">
-          {/* TODO: 신청서 보기 API 연결 */}
-          <button className="mr-10 text-15 font-bold text-st-red">
-            신청서 보기
-          </button>
+          <InfoModal
+            trigger={
+              <button className="mr-10 text-15 font-bold text-st-red">
+                신청서 보기
+              </button>
+            }
+          >
+            <div className="flex flex-col items-center justify-center gap-10">
+              <div className="flex flex-col items-center justify-center gap-10">
+                {steadyQuestionsData.steadyQuestions.map(({ id, content }) => (
+                  <div
+                    key={id}
+                    className="mt-20 flex flex-col items-center justify-center gap-10"
+                  >
+                    <div className={"font-semibold"}>{content}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </InfoModal>
           <InfoModal
             trigger={
               <button className="text-15 font-bold text-st-gray-250">

--- a/src/services/steady/getSteadyQuestions.ts
+++ b/src/services/steady/getSteadyQuestions.ts
@@ -1,0 +1,23 @@
+import { axiosInstance } from "@/services";
+import type { AxiosResponse } from "axios";
+import type { SteadyQuestionsType } from "@/services/types";
+
+const getSteadyQuestions = async (steadyId: string) => {
+  try {
+    const response: AxiosResponse<SteadyQuestionsType> =
+      await axiosInstance.get<SteadyQuestionsType>(
+        `/api/v1/steadies/${steadyId}/questions`,
+      );
+
+    if (Math.floor(response.status / 10) !== 20) {
+      throw new Error("Failed to fetch steady questions!");
+    }
+
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export default getSteadyQuestions;

--- a/src/services/types/index.ts
+++ b/src/services/types/index.ts
@@ -187,3 +187,13 @@ export interface StackResponse {
 export interface PositionResponse {
   positions: PositionType[];
 }
+
+export interface SteadyQuestionsType {
+  steadyQuestions: [
+    {
+      id: number;
+      content: string;
+      sequence: number;
+    },
+  ];
+}


### PR DESCRIPTION
## 📑 구현 사항

- [x] 스테디 모집글 상세 페이지에 신청서 보기 API 연동했습니다!
![Nov-16-2023 09-55-20](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/fdc427b1-9572-459f-9fde-3eee7ab9274e)



## 🚧 특이 사항

- 일단 디자인이 없어서 데이터만 넣은 느낌입니다 ㅎㅎ ㅠ
- 시작하기 전엔 몰랐는데 이거 뭐 너무 규모가 작은 작업이었네요 하핫...😅


## 🚨관련 이슈

close #175 