### PR TITLE
🚨 Fix(#182): 스테디 등록 페이지 1차 QA 반영

### DIFF
--- a/src/app/(steady)/steady/create/page.tsx
+++ b/src/app/(steady)/steady/create/page.tsx
@@ -232,6 +232,7 @@ const CreateSteadyPage = () => {
                       onDateChange={(date) => {
                         field.onChange(formatDate(date));
                       }}
+                      pastSelectable={false}
                     />
                     <FormMessage />
                   </FormItem>

--- a/src/app/(steady)/steady/create/questions/page.tsx
+++ b/src/app/(steady)/steady/create/questions/page.tsx
@@ -55,6 +55,13 @@ const CreateQuestionsPage = () => {
 
   const handleSubmitTotalData = () => {
     const questions = question.map((item) => item.question);
+    if (questions.some((item) => item.length === 0)) {
+      toast({
+        description: "질문의 내용을 입력해주세요.",
+        variant: "red",
+      });
+      return;
+    }
     const totalData = { ...steadyState, questions };
     createSteady(totalData)
       .then(() => {

--- a/src/components/_common/Selector/Date/index.tsx
+++ b/src/components/_common/Selector/Date/index.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 import { CalendarIcon } from "@radix-ui/react-icons";
 import { format } from "date-fns";
+import isPastDate from "@/utils/isPastDate";
 
 interface DateSelectorProps {
   className?: string;
@@ -18,6 +19,7 @@ interface DateSelectorProps {
   initialDate?: Date;
   // eslint-disable-next-line no-unused-vars
   onDateChange?: (date: Date) => void;
+  pastSelectable?: boolean;
 }
 
 const DateSelector = ({
@@ -25,14 +27,22 @@ const DateSelector = ({
   initialLabel,
   initialDate,
   onDateChange,
+  pastSelectable = true,
 }: DateSelectorProps) => {
   const [date, setDate] = useState<Date | undefined>(undefined);
 
-  useEffect(() => {
-    if (initialDate) {
-      setDate(initialDate);
+  const handleSelect = (selected: Date | undefined) => {
+    if (!pastSelectable && selected && isPastDate(selected)) {
+      return;
     }
+    selected && setDate(selected);
+    selected && onDateChange && onDateChange(selected);
+  };
+
+  useEffect(() => {
+    initialDate && setDate(initialDate);
   }, []);
+
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -59,10 +69,7 @@ const DateSelector = ({
           mode="single"
           selected={date}
           onSelect={(selected) => {
-            setDate(selected);
-            if (onDateChange && selected) {
-              onDateChange(selected);
-            }
+            handleSelect(selected);
           }}
           initialFocus
         />

--- a/src/stores/createSteadyData.ts
+++ b/src/stores/createSteadyData.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { SteadyStateType } from "@/constants/schemas/steadySchema";
 
-const CreateSteadyStorageKey = "create-steady-key";
+const CreateSteadyStorageKey = "steadyState";
 
 interface CreateSteadyState {
   steadyState: SteadyStateType;

--- a/src/utils/isPastDate.ts
+++ b/src/utils/isPastDate.ts
@@ -1,0 +1,13 @@
+const isPastDate = (date: Date) => {
+  const today = new Date();
+  if (date.getMonth() < today.getMonth()) {
+    return true;
+  } else if (date.getMonth() === today.getMonth()) {
+    if (date.getDate() < today.getDate()) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export default isPastDate;


### PR DESCRIPTION
## 📑 구현 사항

- [x] 마감일 선택 UI가 과거 날짜를 선택하지 못하도록 변경했습니다!
![Nov-19-2023 01-17-39](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/233780e9-c94f-4db9-9ec5-f45f407cac67)


- [x] 스테디 질문 등록 시 내용이 빈 질문은 등록하지 못하도록 변경했습니다!
![Nov-19-2023 01-17-45](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/747d4ca0-896b-4956-9cb8-a94d7ed6a9f5)


## 🚧 특이 사항

- 전역 상태 키 값이 원래 `create-steady-key` 였는데 스테디 정보를 담는 상태라서 `steadyState`로 변경했습니다!


## 🚨관련 이슈

close #182