### PR TITLE
💄 Style(#199): 스테디 등록 페이지 디자인 변경

### DIFF
--- a/src/app/(steady)/steady/create/page.tsx
+++ b/src/app/(steady)/steady/create/page.tsx
@@ -19,6 +19,7 @@ import getStacks from "@/services/steady/getStacks";
 import type { PositionResponse, StackResponse } from "@/services/types";
 import Button, { buttonSize } from "@/components/_common/Button";
 import Input from "@/components/_common/Input";
+import AlertModal from "@/components/_common/Modal/AlertModal";
 import {
   DateSelector,
   MultiSelector,
@@ -39,7 +40,7 @@ import { SteadySchema } from "@/constants/schemas/steadySchema";
 
 const CreateSteadyPage = () => {
   const router = useRouter();
-  const { setSteadyState } = useCreateSteadyStore();
+  const { steadyState, setSteadyState } = useCreateSteadyStore();
   const steadyForm = useForm<SteadyStateType>({
     resolver: zodResolver(SteadySchema),
   });
@@ -65,6 +66,13 @@ const CreateSteadyPage = () => {
   const onSubmit = (data: SteadyStateType) => {
     setSteadyState(data);
     router.push("/steady/create/questions");
+  };
+
+  const handleCancelProcess = () => {
+    if (steadyState) {
+      useCreateSteadyStore.persist.clearStorage();
+    }
+    router.replace("/");
   };
 
   return (
@@ -296,11 +304,32 @@ const CreateSteadyPage = () => {
               )}
             />
             <div className={"flex justify-end gap-20"}>
-              <Button
-                className={cn(`${buttonSize.sm} items-center justify-center`)}
+              <AlertModal
+                actionButton={
+                  <Button
+                    className={cn(
+                      `bg-st-red ${buttonSize.sm} items-center justify-center text-st-white`,
+                    )}
+                    onClick={handleCancelProcess}
+                  >
+                    돌아가기
+                  </Button>
+                }
+                trigger={
+                  <Button
+                    className={cn(
+                      `${buttonSize.sm} items-center justify-center`,
+                    )}
+                  >
+                    취소
+                  </Button>
+                }
               >
-                취소
-              </Button>
+                <div className="text-18 font-bold">
+                  메인 페이지로 돌아갈까요? <br /> 작성하시던 데이터가
+                  사라집니다!
+                </div>
+              </AlertModal>
               <Button
                 className={cn(
                   `bg-st-primary ${buttonSize.sm} items-center justify-center text-st-white`,

--- a/src/app/(steady)/steady/create/page.tsx
+++ b/src/app/(steady)/steady/create/page.tsx
@@ -27,9 +27,8 @@ import {
 import { extractValue } from "@/utils/extractValue";
 import { formatDate } from "@/utils/formatDate";
 import {
-  RECRUITMENT_SECTION_INTRO,
+  CREATE_STEADY_PAGE_HEADING,
   STEADY_RECRUITMENT_EXAMPLE,
-  STEADY_SECTION_INTRO,
   steadyCategories,
   steadyExpectedPeriods,
   steadyParticipantsLimit,
@@ -72,52 +71,13 @@ const CreateSteadyPage = () => {
     <div className={cn("mt-30")}>
       <Form {...steadyForm}>
         <form onSubmit={steadyForm.handleSubmit(onSubmit)}>
-          <h1 className={cn("mx-8 font-semibold")}>{STEADY_SECTION_INTRO}</h1>
+          <h1 className={cn("mx-8 font-semibold")}>
+            {CREATE_STEADY_PAGE_HEADING}
+          </h1>
           <Separator
             size={"4"}
             my={"3"}
-            className={cn("h-5 bg-st-gray-400")}
-          />
-          <div className={cn("mx-40 flex flex-row justify-between")}>
-            <FormField
-              control={steadyForm.control}
-              name={"type"}
-              render={({ field }) => (
-                <FormItem>
-                  <SingleSelector
-                    initialLabel={"프로젝트 / 스터디"}
-                    items={steadyCategories}
-                    className={cn("w-430")}
-                    onSelectedChange={(selected) => {
-                      field.onChange(selected);
-                    }}
-                  />
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={steadyForm.control}
-              name={"participantLimit"}
-              render={({ field }) => (
-                <FormItem>
-                  <SingleSelector
-                    initialLabel={"스테디 정원"}
-                    items={steadyParticipantsLimit}
-                    className={cn("w-430")}
-                    onSelectedChange={(selected) => {
-                      field.onChange(Number(selected));
-                    }}
-                  />
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-          <Separator
-            size={"4"}
-            my={"3"}
-            className={cn("h-5 bg-st-gray-400")}
+            className={cn("h-3 bg-st-gray-400")}
           />
           <FormField
             control={steadyForm.control}
@@ -136,18 +96,17 @@ const CreateSteadyPage = () => {
               </FormItem>
             )}
           />
+          <div className={cn("my-10")}></div>
           <FormField
             control={steadyForm.control}
             name={"bio"}
             render={({ field }) => (
               <FormItem>
                 <FormControl>
-                  <TextArea
-                    className={cn("h-380 w-full")}
-                    my={"3"}
-                    placeholder={"스테디 소개"}
-                    onChange={(event) => {
-                      field.onChange(event.target.value);
+                  <Input
+                    inputName={"steady-bio-input"}
+                    onValueChange={(value) => {
+                      field.onChange(value);
                     }}
                   />
                 </FormControl>
@@ -156,29 +115,25 @@ const CreateSteadyPage = () => {
             )}
           />
           <div className={cn("mt-30")}>
-            <h1 className={cn("mx-8 font-semibold")}>
-              {RECRUITMENT_SECTION_INTRO}
-            </h1>
             <Separator
               size={"4"}
               my={"3"}
-              className={cn("h-5 bg-st-gray-400")}
+              className={cn("h-3 bg-st-gray-400")}
             />
-            <div className={cn("mx-20 flex flex-row justify-between gap-15")}>
+            <div
+              className={cn("mx-20 my-10 flex flex-row justify-between gap-15")}
+            >
               <FormField
                 control={steadyForm.control}
-                name={"positions"}
+                name={"type"}
                 render={({ field }) => (
                   <FormItem>
-                    <MultiSelector
-                      initialLabel={"모집 분야"}
-                      items={positions.positions.map((position) => ({
-                        value: position.id.toString(),
-                        label: position.name,
-                      }))}
+                    <SingleSelector
+                      initialLabel={"프로젝트 / 스터디"}
+                      items={steadyCategories}
                       className={cn("w-200")}
                       onSelectedChange={(selected) => {
-                        field.onChange(extractValue(selected).map(Number));
+                        field.onChange(selected);
                       }}
                     />
                     <FormMessage />
@@ -206,21 +161,22 @@ const CreateSteadyPage = () => {
 
               <FormField
                 control={steadyForm.control}
-                name={"scheduledPeriod"}
+                name={"participantLimit"}
                 render={({ field }) => (
                   <FormItem>
                     <SingleSelector
-                      initialLabel={"예상 기간"}
-                      items={steadyExpectedPeriods}
+                      initialLabel={"스테디 정원"}
+                      items={steadyParticipantsLimit}
                       className={cn("w-200")}
                       onSelectedChange={(selected) => {
-                        field.onChange(selected);
+                        field.onChange(Number(selected));
                       }}
                     />
                     <FormMessage />
                   </FormItem>
                 )}
               />
+
               <FormField
                 control={steadyForm.control}
                 name={"deadline"}
@@ -238,7 +194,48 @@ const CreateSteadyPage = () => {
                 )}
               />
             </div>
-            <div className={cn("mx-20 flex flex-row justify-start gap-15")}>
+            <div
+              className={cn("mx-20 my-10 flex flex-row justify-between gap-15")}
+            >
+              <FormField
+                control={steadyForm.control}
+                name={"positions"}
+                render={({ field }) => (
+                  <FormItem>
+                    <MultiSelector
+                      initialLabel={"모집 분야"}
+                      items={positions.positions.map((position) => ({
+                        value: position.id.toString(),
+                        label: position.name,
+                      }))}
+                      className={cn("w-200")}
+                      onSelectedChange={(selected) => {
+                        field.onChange(extractValue(selected).map(Number));
+                      }}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={steadyForm.control}
+                name={"scheduledPeriod"}
+                render={({ field }) => (
+                  <FormItem>
+                    <SingleSelector
+                      initialLabel={"예상 기간"}
+                      items={steadyExpectedPeriods}
+                      className={cn("w-200")}
+                      onSelectedChange={(selected) => {
+                        field.onChange(selected);
+                      }}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
               <FormField
                 control={steadyForm.control}
                 name={"stacks"}
@@ -250,7 +247,7 @@ const CreateSteadyPage = () => {
                         value: stack.id.toString(),
                         label: stack.name,
                       }))}
-                      className={cn("w-280")}
+                      className={cn("w-455")}
                       onSelectedChange={(selected) => {
                         field.onChange(extractValue(selected).map(Number));
                       }}
@@ -264,7 +261,7 @@ const CreateSteadyPage = () => {
             <Separator
               size={"4"}
               my={"3"}
-              className={cn("h-5 bg-st-gray-400")}
+              className={cn("h-3 bg-st-gray-400")}
             />
             <FormField
               control={steadyForm.control}

--- a/src/app/(steady)/steady/create/questions/page.tsx
+++ b/src/app/(steady)/steady/create/questions/page.tsx
@@ -170,7 +170,10 @@ const CreateQuestionsPage = () => {
         className={cn("h-5 bg-st-gray-400")}
       />
       <div className={"flex justify-end gap-20"}>
-        <Button className={cn(`${buttonSize.sm} items-center justify-center`)}>
+        <Button
+          className={cn(`${buttonSize.sm} items-center justify-center`)}
+          onClick={() => router.back()}
+        >
           취소
         </Button>
         <Button

--- a/src/components/_common/Input/index.tsx
+++ b/src/components/_common/Input/index.tsx
@@ -9,7 +9,8 @@ interface InputProps extends ComponentProps<"input"> {
     | "steady-title-input"
     | "title-input"
     | "tag-input"
-    | "introduce-input";
+    | "introduce-input"
+    | "steady-bio-input";
   initialValue?: string;
   // eslint-disable-next-line no-unused-vars
   onValueChange?: (value: string) => void;
@@ -57,6 +58,21 @@ const Input = ({
             type="text"
             defaultValue={initialValue}
             placeholder="스테디명"
+            onChange={(event) => {
+              onValueChange?.(event.target.value);
+            }}
+          />
+        </div>
+      );
+      break;
+    case "steady-bio-input":
+      input = (
+        <div>
+          <input
+            className="h-30 w-1000 pl-5 pr-5 text-2xl font-bold outline-none"
+            type="text"
+            defaultValue={initialValue}
+            placeholder="스테디 한 줄 소개"
             onChange={(event) => {
               onValueChange?.(event.target.value);
             }}

--- a/src/constants/create-steady.ts
+++ b/src/constants/create-steady.ts
@@ -13,6 +13,9 @@ export const STEADY_SECTION_INTRO = "📖 스테디 정보를 입력해주세요
 
 export const RECRUITMENT_SECTION_INTRO = "✍️ 모집글 정보를 입력해주세요.";
 
+export const CREATE_STEADY_PAGE_HEADING =
+  "📖 스테디 / ✍️ 모집글 정보를 입력해주세요.";
+
 export const STEADY_RESPONSE_MOCK_DATA = {
   id: 1,
   nickname: "닉네임",


### PR DESCRIPTION
## 📑 구현 사항

- [x] 스테디 등록 페이지의 외형을 수정된 디자인에 맞춰 변경했습니다!
![Nov-19-2023 02-15-22](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/c51756a3-7901-4954-a084-aa10ef80c42d)

- [x] 취소 버튼의 기능이 등록돼있지 않아서 등록해주었습니다!
    - 질문 등록 페이지의 경우 스테디 등록 페이지로 돌아가도록 했습니다! 그런데 작성하던 데이터는 보이지 않습니다...?
    - 스테디 등록 페이지의 경우 취소 버튼 클릭 시 작성 중인 데이터의 삭제 및 메인 페이지로 이동됨을 안내하며, 돌아가기 버튼 클릭 시 로컬 스토리지에 있을 수 있는 데이터를 지우고 메인 페이지로 이동시키게 됩니다.


## 🚧 특이 사항

- [1e1358f](https://github.com/Team-Blitz-Steady/steady-client/commit/1e1358f2b48d98f85654bb638341361e3f81e915) 커밋 메시지에서 스테디 `생성` 페이지라고 작성했네요 ㅠㅠ 별도의 페이지가 있는 것이 아니라 본문에서 언급 중인 등록 페이지가 맞습니다..
- 기존 헤딩 문구 데이터는 스테디 수정 페이지에서도 사용 중이기 때문에, 해당 페이지의 외형을 변경할 때 삭제될 예정입니다.
- 일단 어디까지나 외형 변경이 메인이었던 이슈여서 추가한 취소 기능의 엣지 케이스 대응은 추후 이슈 생성 후 진행하겠습니다!
- 스테디 수정 페이지 외형 또한 금방 변경해서 PR 올리겠습니다!

## 🚨관련 이슈

close #199 