### PR TITLE
✨ Feat(#214): 알림 기능 구현

### DIFF
--- a/src/components/_common/AppBar/index.tsx
+++ b/src/components/_common/AppBar/index.tsx
@@ -21,7 +21,7 @@ import {
   RocketIcon,
 } from "@radix-ui/react-icons";
 import { Avatar, IconButton, Separator } from "@radix-ui/themes";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import deleteAllNotifications from "@/services/notification/deleteAllNotifications";
 import deleteNotification from "@/services/notification/deleteNotification";
 import getAllNotifications from "@/services/notification/getAllNotifications";
@@ -29,6 +29,7 @@ import readAllNotifications from "@/services/notification/readAllNotifications";
 import readNotification from "@/services/notification/readNotification";
 import Button from "@/components/_common/Button";
 import Dropdown from "@/components/_common/Dropdown";
+import Spinner from "@/components/_common/Spinner";
 import LoginModal from "../Modal/LoginModal";
 
 interface AppBarProps {
@@ -39,19 +40,28 @@ export const appBarTextStyles = "text-lg font-bold";
 
 const AppBar = ({ className }: AppBarProps) => {
   const router = useRouter();
+  const { isAuth } = useAuthStore();
   const [notificationMenuOpen, setNotificationMenuOpen] = useState(false);
   const {
     data: notificationsData,
+    isSuccess: notificationsSuccess,
     error: notificationsError,
     refetch: refetchNotifications,
-  } = useSuspenseQuery({
+  } = useQuery({
     queryKey: ["notifications"],
     queryFn: () => getAllNotifications(),
+    enabled: isAuth,
   });
+
   if (notificationsError) {
     console.error(notificationsError);
     refetchNotifications();
   }
+
+  if (!notificationsSuccess) {
+    return <Spinner size={"small"} />;
+  }
+
   const { notifications, freshCount } = notificationsData;
 
   const handleNavigateTo = (id: string, path: string) => {
@@ -86,7 +96,6 @@ const AppBar = ({ className }: AppBarProps) => {
     });
   };
 
-  const { isAuth } = useAuthStore();
   return (
     <div
       className={cn(

--- a/src/components/_common/AppBar/index.tsx
+++ b/src/components/_common/AppBar/index.tsx
@@ -135,7 +135,7 @@ const AppBar = ({ className }: AppBarProps) => {
                 />
               </div>
             </PopoverTrigger>
-            <PopoverContent className={"h-300 w-350 p-16 pb-35"}>
+            <PopoverContent className={"h-300 w-350 p-16 pb-40"}>
               <ScrollArea
                 className={"h-full w-full rounded-md"}
                 scrollBarClassName={"hidden"}
@@ -212,9 +212,7 @@ const AppBar = ({ className }: AppBarProps) => {
                   )}
                 </div>
               </ScrollArea>
-              <div
-                className={"mb-4 flex h-35 w-full items-center justify-between"}
-              >
+              <div className={"flex h-35 w-full items-end justify-evenly"}>
                 <Button
                   className={cn("h-30 w-1/3 bg-st-primary text-st-white")}
                   onClick={() => handleReadAllNotification()}

--- a/src/components/_common/AppBar/index.tsx
+++ b/src/components/_common/AppBar/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   Popover,
   PopoverContent,
@@ -40,7 +40,9 @@ export const appBarTextStyles = "text-lg font-bold";
 
 const AppBar = ({ className }: AppBarProps) => {
   const router = useRouter();
+  const pathName = usePathname();
   const { isAuth } = useAuthStore();
+
   const [notificationMenuOpen, setNotificationMenuOpen] = useState(false);
   const {
     data: notificationsData,
@@ -58,8 +60,16 @@ const AppBar = ({ className }: AppBarProps) => {
     refetchNotifications();
   }
 
+  useEffect(() => {
+    refetchNotifications();
+  }, [pathName]);
+
   if (!notificationsSuccess) {
-    return <Spinner size={"small"} />;
+    return (
+      <div className={"flex h-112 w-full items-center justify-center"}>
+        <Spinner size={"medium"} />
+      </div>
+    );
   }
 
   const { notifications, freshCount } = notificationsData;
@@ -135,6 +145,7 @@ const AppBar = ({ className }: AppBarProps) => {
                 />
               </div>
             </PopoverTrigger>
+
             <PopoverContent className={"h-300 w-350 p-16 pb-40"}>
               <ScrollArea
                 className={"h-full w-full rounded-md"}
@@ -144,88 +155,111 @@ const AppBar = ({ className }: AppBarProps) => {
                   <h4 className="mb-16 text-20 font-semibold leading-none">
                     알림 목록
                   </h4>
-                  {notifications.map(
-                    ({ id, content, type, redirectUri, isRead }) => (
-                      <div
-                        className={"flex justify-center py-10"}
-                        key={id}
-                      >
-                        <div className={"flex items-center px-5"}>
-                          {(type === "FRESH_APPLICATION" && (
-                            <RocketIcon
-                              width={20}
-                              height={20}
-                              color={"black"}
-                            />
-                          )) ||
-                            (type === "APPLICATION_RESULT" && (
-                              <FileTextIcon
-                                width={20}
-                                height={20}
-                                color={"blue"}
-                              />
-                            ))}
-                        </div>
+                  {notifications.length > 0 ? (
+                    <>
+                      {notifications.map(
+                        ({ id, content, type, redirectUri, isRead }) => (
+                          <div
+                            className={"flex justify-center py-10"}
+                            key={id}
+                          >
+                            <div className={"flex items-center px-5"}>
+                              {(type === "FRESH_APPLICATION" && (
+                                <RocketIcon
+                                  width={20}
+                                  height={20}
+                                  color={"black"}
+                                />
+                              )) ||
+                                (type === "APPLICATION_RESULT" && (
+                                  <FileTextIcon
+                                    width={20}
+                                    height={20}
+                                    color={"blue"}
+                                  />
+                                ))}
+                            </div>
 
-                        <div
-                          className={cn(
-                            "text-md cursor-pointer",
-                            isRead ? "text-st-gray-250" : "text-st-black",
-                          )}
-                          onClick={() =>
-                            handleNavigateTo(id.toString(), redirectUri)
-                          }
-                        >
-                          {content}
-                        </div>
-                        <div className={"flex items-center gap-8"}>
-                          <IconButton
-                            className={"cursor-pointer"}
-                            onClick={() =>
-                              handleReadNotification(id.toString())
-                            }
-                            size={"2"}
-                          >
-                            <CheckIcon
-                              width={20}
-                              height={20}
-                              color={"green"}
-                            />
-                          </IconButton>
-                          <IconButton
-                            className={"cursor-pointer"}
-                            onClick={() =>
-                              handleDeleteNotification(id.toString())
-                            }
-                            size={"2"}
-                          >
-                            <Cross2Icon
-                              width={20}
-                              height={20}
-                              color={"red"}
-                            />
-                          </IconButton>
-                        </div>
-                        <Separator className="my-2 h-2 bg-st-gray-400" />
-                      </div>
-                    ),
+                            <div
+                              className={cn(
+                                "text-md cursor-pointer",
+                                isRead ? "text-st-gray-250" : "text-st-black",
+                              )}
+                              onClick={() =>
+                                handleNavigateTo(id.toString(), redirectUri)
+                              }
+                            >
+                              {content}
+                            </div>
+                            <div className={"flex items-center gap-8"}>
+                              <IconButton
+                                className={"cursor-pointer"}
+                                onClick={() =>
+                                  handleReadNotification(id.toString())
+                                }
+                                size={"2"}
+                              >
+                                <CheckIcon
+                                  width={20}
+                                  height={20}
+                                  color={"green"}
+                                />
+                              </IconButton>
+                              <IconButton
+                                className={"cursor-pointer"}
+                                onClick={() =>
+                                  handleDeleteNotification(id.toString())
+                                }
+                                size={"2"}
+                              >
+                                <Cross2Icon
+                                  width={20}
+                                  height={20}
+                                  color={"red"}
+                                />
+                              </IconButton>
+                            </div>
+                            <Separator className="my-2 h-2 bg-st-gray-400" />
+                          </div>
+                        ),
+                      )}
+                    </>
+                  ) : (
+                    <div
+                      className={
+                        "flex h-full w-full flex-row items-center justify-center py-80 text-st-gray-250"
+                      }
+                    >
+                      알림이 없습니다.
+                    </div>
                   )}
                 </div>
+                {/*{notifications.length <= 0 && (*/}
+                {/*  <div*/}
+                {/*    className={*/}
+                {/*      "h-full w-full items-center justify-center text-st-gray-250"*/}
+                {/*    }*/}
+                {/*  >*/}
+                {/*    알림이 없습니다.*/}
+                {/*  </div>*/}
+                {/*)}*/}
               </ScrollArea>
-              <div className={"flex h-35 w-full items-end justify-evenly"}>
-                <Button
-                  className={cn("h-30 w-1/3 bg-st-primary text-st-white")}
-                  onClick={() => handleReadAllNotification()}
-                >
-                  모두 읽음
-                </Button>
-                <Button
-                  className={cn("h-30 w-1/3 bg-st-red text-st-white")}
-                  onClick={() => handleDeleteAllNotification()}
-                >
-                  모두 삭제
-                </Button>
-              </div>
+              {notifications.length > 0 && (
+                <div className={"flex h-35 w-full items-end justify-evenly"}>
+                  <Button
+                    className={cn("h-30 w-1/3 bg-st-primary text-st-white")}
+                    onClick={() => handleReadAllNotification()}
+                  >
+                    모두 읽음
+                  </Button>
+                  <Button
+                    className={cn("h-30 w-1/3 bg-st-red text-st-white")}
+                    onClick={() => handleDeleteAllNotification()}
+                  >
+                    모두 삭제
+                  </Button>
+                </div>
+              )}
             </PopoverContent>
           </Popover>
           <Dropdown

--- a/src/components/_common/AppBar/index.tsx
+++ b/src/components/_common/AppBar/index.tsx
@@ -234,15 +234,6 @@ const AppBar = ({ className }: AppBarProps) => {
                     </div>
                   )}
                 </div>
-                {/*{notifications.length <= 0 && (*/}
-                {/*  <div*/}
-                {/*    className={*/}
-                {/*      "h-full w-full items-center justify-center text-st-gray-250"*/}
-                {/*    }*/}
-                {/*  >*/}
-                {/*    알림이 없습니다.*/}
-                {/*  </div>*/}
-                {/*)}*/}
               </ScrollArea>
               {notifications.length > 0 && (
                 <div className={"flex h-35 w-full items-end justify-evenly"}>

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -6,8 +6,10 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+    scrollBarClassName?: string;
+  }
+>(({ className, children, scrollBarClassName, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn("relative overflow-hidden", className)}
@@ -16,7 +18,7 @@ const ScrollArea = React.forwardRef<
     <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
+    <ScrollBar className={scrollBarClassName} />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
 ));


### PR DESCRIPTION
## 📑 구현 사항

![Nov-21-2023 00-12-09](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/b1531eef-247b-4798-9e0f-3f301482058d)
- [x] 기존 더미 데이터를 기반으로 동작하던 알림 컴포넌트에 API를 연동하여 알림 기능을 구현했습니다!
- [x] 응답 데이터에 담겨오는 redirect url을 통해 해당 알림과 연관된 페이지로 이동합니다!
- [x] 이동할 시 해당 알림은 자동으로 읽음 처리 됩니다.

![Nov-21-2023 00-12-15](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/5db101c9-396d-4647-b0a7-414a0d1a32e7)
- [x] 체크 아이콘을 눌러서 읽음 처리할 수 있습니다! 읽음 처리된 알림은 텍스트 색상이 회색입니다.
![Nov-21-2023 00-12-29](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/7635c3bc-6dce-4c16-8fc4-10dca76a7ac7)
- [x] X 아이콘을 눌러서 삭제 처리할 수 있습니다! 삭제 처리된 알림은 더 이상 보이지 않게 됩니다.
![Nov-21-2023 00-12-35](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/328825b3-cb68-453a-8b9d-4f24a0b2f333)
![Nov-21-2023 00-12-39](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/dc622ecf-a951-4fdb-8a4f-91954d16535b)
- [x] 알림 메뉴 하단에 고정된 버튼을 통해 모두 읽음, 모두 삭제 처리를 할 수 있습니다!


## 🚧 특이 사항

- TODO: 알림이 없으면 "아직 도착한 알림이 없어요! 😀 " 같은 대체 UI를 표시하는 기능을 생각하고 있는데 추후 추가하겠습니다!
- TODO: 현재 알림창 사이에 구분선이 없는데, 1차 QA 이후 추가하도록 하겠습니다.
- TODO: 알림은 유저가 사이트를 이용 중인 상황에도 발생할 수 있기 떄문에, 일정 Interval 또는 페이지 전환 시 refetch를 할 수 있도록 변경하려고 합니다!

- ScrollArea에서 스크롤바를 숨기고 싶은 상황이 몇 번 있었는데, 이번이 특히 그래서 새로운 Prop을 받도록 변경했습니다!
```jsx
// ...
<ScrollArea
  className={"h-full w-full rounded-md"}
  scrollBarClassName={"hidden"}
>
// ...
```
위와 같이 `ScrollArea` 컴포넌트에 scrollBarClassName Prop으로 className을 전달할 수 있습니다!

## 🚨관련 이슈

close #214