### PR TITLE
✨ Feat(#219): 질문 등록 / 수정 페이지 질문 추가 기능 개선

### DIFF
--- a/src/app/(steady)/steady/create/questions/page.tsx
+++ b/src/app/(steady)/steady/create/questions/page.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 import useCreateSteadyStore from "@/stores/createSteadyData";
 import { Separator } from "@radix-ui/themes";
+import { Command } from "cmdk";
 import createSteady from "@/services/steady/createSteady";
 import Button, { buttonSize } from "@/components/_common/Button";
 import Icon from "@/components/_common/Icon";
@@ -28,7 +29,14 @@ const CreateQuestionsPage = () => {
     }
   }, [router, steadyState, toast]);
 
-  const handleCreateQuestion = () => {
+  useEffect(() => {
+    const curInput = question.reduce((prev, cur) => {
+      return cur.id > prev.id ? cur : prev;
+    });
+    document.getElementById(`question-${curInput.id}`)?.focus();
+  }, [question.length]);
+
+  const handleAddQuestion = () => {
     if (question.length === 10) {
       toast({
         description: "질문은 최대 10개까지만 추가할 수 있습니다.",
@@ -80,6 +88,12 @@ const CreateQuestionsPage = () => {
       });
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter") {
+      handleAddQuestion();
+    }
+  };
+
   return (
     <div className={cn("mt-30")}>
       <div className={"flex w-1000 items-center justify-between"}>
@@ -95,7 +109,7 @@ const CreateQuestionsPage = () => {
               `h-40 w-130 items-center justify-center bg-st-primary text-st-white`,
             )}
             onClick={() => {
-              handleCreateQuestion();
+              handleAddQuestion();
             }}
           >
             질문 추가
@@ -124,26 +138,29 @@ const CreateQuestionsPage = () => {
                 <div
                   className={cn("h-60 w-10 rounded-full bg-st-skyblue-300")}
                 ></div>
-                <input
-                  type="text"
-                  placeholder="질문을 입력해 주세요."
-                  className={cn(
-                    "h-50 w-300 text-20 font-semibold text-st-black outline-none",
-                  )}
-                  onChange={(event) => {
-                    setQuestion((prev) =>
-                      prev.map((pItem) => {
-                        if (pItem.id === item.id) {
-                          return {
-                            ...pItem,
-                            question: event.target.value,
-                          };
-                        }
-                        return pItem;
-                      }),
-                    );
-                  }}
-                />
+                <Command onKeyDown={handleKeyDown}>
+                  <input
+                    id={`question-${item.id}`}
+                    type="text"
+                    placeholder="질문을 입력해 주세요."
+                    className={cn(
+                      "h-50 w-300 text-20 font-semibold text-st-black outline-none",
+                    )}
+                    onChange={(event) => {
+                      setQuestion((prev) =>
+                        prev.map((pItem) => {
+                          if (pItem.id === item.id) {
+                            return {
+                              ...pItem,
+                              question: event.target.value,
+                            };
+                          }
+                          return pItem;
+                        }),
+                      );
+                    }}
+                  />
+                </Command>
                 <div
                   className={cn("cursor-pointer")}
                   onClick={() => {

--- a/src/app/(steady)/steady/edit/questions/[id]/page.tsx
+++ b/src/app/(steady)/steady/edit/questions/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 import { Separator } from "@radix-ui/themes";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Command } from "cmdk";
 import getSteadyQuestions from "@/services/steady/getSteadyQuestions";
 import updateSteadyQuestions from "@/services/steady/updateSteadyQuestions";
 import Button, { buttonSize } from "@/components/_common/Button";
@@ -38,6 +39,15 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
       );
     }
   }, []);
+
+  useEffect(() => {
+    const curInput = question.find(
+      (item) =>
+        item.sequence === Math.max(...question.map((item) => item.sequence)),
+    );
+    document.getElementById(`question-${curInput?.sequence}`)?.focus();
+  }, [question.length]);
+
   const { toast } = useToast();
   const router = useRouter();
 
@@ -87,6 +97,12 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
         });
       }
     });
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter") {
+      handleAddQuestion();
+    }
   };
 
   const handleDeleteQuestion = (sequence: number) => {
@@ -140,17 +156,20 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
                 <div
                   className={cn("h-60 w-10 rounded-full bg-st-skyblue-300")}
                 ></div>
-                <input
-                  type="text"
-                  placeholder="질문을 입력해 주세요."
-                  value={item.question}
-                  className={cn(
-                    `h-50 min-w-[300px] text-20 font-semibold text-st-black outline-none`,
-                  )}
-                  onChange={(event) => {
-                    handleInputQuestion(event, item.sequence);
-                  }}
-                />
+                <Command onKeyDown={handleKeyDown}>
+                  <input
+                    id={`question-${item.sequence}`}
+                    type="text"
+                    placeholder="질문을 입력해 주세요."
+                    value={item.question}
+                    className={cn(
+                      `h-50 min-w-[300px] text-20 font-semibold text-st-black outline-none`,
+                    )}
+                    onChange={(event) => {
+                      handleInputQuestion(event, item.sequence);
+                    }}
+                  />
+                </Command>
                 <div
                   className={cn("cursor-pointer")}
                   onClick={() => {


### PR DESCRIPTION
## 📑 구현 사항

![Nov-23-2023 01-27-24](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/b4d4875d-e12d-4f2a-a8ea-e432ccc50341)

- [x] 질문 등록 페이지에서 엔터키를 누르면 자동으로 질문 입력칸이 추가되고 포커스 됩니다.
- [x] 질문 수정 페이지에서 엔터키를 누르면 자동으로 질문 입력칸이 추가되고 포커스 됩니다.


## 🚧 특이 사항

- 두 사이트의 질문 데이터 식별자가 달라서 구현 방식은 조~금 다르지만 cmdk의 Command 컴포넌트에서 Enter 키보드 입력을 감지하고 질문 추가 함수를 실행하는 것과, useEffect 훅을 활용해서 자동 포커스 시켜주는 로직은 결이 같습니다!


## 🚨관련 이슈

close #219