### PR TITLE
✨ Feat(#256): 질문 등록 / 수정 페이지 템플릿 정보 불러오기 / 질문 템플릿으로 저장하기 기능 추가

### DIFF
--- a/src/app/(steady)/steady/edit/questions/[id]/page.tsx
+++ b/src/app/(steady)/steady/edit/questions/[id]/page.tsx
@@ -11,13 +11,21 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Command } from "cmdk";
 import getSteadyQuestions from "@/services/steady/getSteadyQuestions";
 import updateSteadyQuestions from "@/services/steady/updateSteadyQuestions";
+import { createTemplate } from "@/services/template/createTemplate";
+import getTemplateDetail from "@/services/template/getTemplateDetail";
+import getTemplates from "@/services/template/getTemplates";
 import Button, { buttonSize } from "@/components/_common/Button";
 import Icon from "@/components/_common/Icon";
+import InputModal from "@/components/_common/Modal/InputModal";
 import { SingleSelector } from "@/components/_common/Selector";
-import { getSteadyEditQuestionsKey } from "@/constants/queryKeys";
+import { TemplatesKey, getSteadyEditQuestionsKey } from "@/constants/queryKeys";
+import { BASIC_QUESTION, BASIC_TEMPLATE } from "@/constants/selectorItems";
 
 const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
   const steadyId = params.id;
+  const { toast } = useToast();
+  const router = useRouter();
+
   const {
     data: questionsData,
     error,
@@ -27,9 +35,19 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
     queryFn: () => getSteadyQuestions(steadyId),
   });
 
+  const {
+    data: templatesData,
+    error: templatesError,
+    refetch: refetchTemplates,
+  } = useSuspenseQuery({
+    queryKey: [TemplatesKey],
+    queryFn: () => getTemplates(),
+  });
+
   const [question, setQuestion] = useState<
     { question: string; sequence: number }[]
   >([]);
+  const [isTemplateTitleSetting, setIsTemplateTitleSetting] = useState(false);
 
   useEffect(() => {
     if (questionsData) {
@@ -50,13 +68,10 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
     document.getElementById(`question-${curInput?.sequence}`)?.focus();
   }, [question.length]);
 
-  const { toast } = useToast();
-  const router = useRouter();
-
-  if (error) {
+  if (error || templatesError) {
     return (
       <div>
-        <h1>에러가 발생했습니다.</h1>
+        <h1>정보를 불러오는 도중에 에러가 발생했습니다. </h1>
       </div>
     );
   }
@@ -121,6 +136,44 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
     setQuestion((prev) => prev.filter((item) => item.sequence !== sequence));
   };
 
+  const handleSelectTemplate = (id: string) => {
+    if (id === "0") {
+      setQuestion(
+        BASIC_QUESTION.map((item, index) => ({ ...item, sequence: index + 1 })),
+      );
+      return;
+    }
+    getTemplateDetail(id).then((res) => {
+      setQuestion(
+        res.questions.map((content, index) => ({
+          sequence: index + 1,
+          question: content,
+        })),
+      );
+    });
+  };
+
+  const handleSaveTemplate = (title: string) => {
+    const templateData = {
+      title: title,
+      questions: question.map((item) => item.question),
+    };
+    createTemplate(templateData)
+      .then(() => {
+        toast({
+          description: "질문 템플릿이 성공적으로 저장되었습니다.",
+          variant: "green",
+        });
+        refetchTemplates();
+      })
+      .catch(() => {
+        toast({
+          description: "질문 템플릿 저장에 실패하였습니다.",
+          variant: "red",
+        });
+      });
+  };
+
   return (
     <div className={cn("mt-30")}>
       <div className={"flex w-1000 items-center justify-between"}>
@@ -128,8 +181,16 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
         <div className={"flex items-center gap-10"}>
           <SingleSelector
             className={cn("h-40 w-260")}
-            items={[]}
-            initialLabel={"신청서"}
+            items={BASIC_TEMPLATE.concat(templatesData.templates).map(
+              (item) => ({
+                value: item.id.toString(),
+                label: item.title,
+              }),
+            )}
+            initialLabel={"질문 템플릿"}
+            onSelectedChange={(selected) => {
+              handleSelectTemplate(selected);
+            }}
           />
           <Button
             className={cn(
@@ -197,6 +258,9 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
             className={cn(
               `${buttonSize.sm} items-center justify-center bg-st-primary text-st-white`,
             )}
+            onClick={() => {
+              setIsTemplateTitleSetting(true);
+            }}
           >
             저장
           </Button>
@@ -225,6 +289,11 @@ const EditQuestionsPage = ({ params }: { params: { id: string } }) => {
           수정
         </Button>
       </div>
+      <InputModal
+        isOpen={isTemplateTitleSetting}
+        onClose={() => setIsTemplateTitleSetting(false)}
+        onSave={handleSaveTemplate}
+      />
     </div>
   );
 };

--- a/src/constants/selectorItems.ts
+++ b/src/constants/selectorItems.ts
@@ -40,3 +40,10 @@ export const steadyRecruitmentStatus = [
   { value: "RECRUITING", label: "모집중" },
   { value: "CLOSED", label: "마감" },
 ];
+
+export const BASIC_TEMPLATE = [{ id: 0, title: "기본 템플릿", createdAt: "" }];
+
+export const BASIC_QUESTION = [
+  { id: 1, question: "기본 질문 1" },
+  { id: 2, question: "기본 질문 2" },
+];


### PR DESCRIPTION
## 📑 구현 사항

![Nov-26-2023 00-30-26](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/bd102fd6-914c-4110-bb51-a269ea4f53fa)

![Nov-26-2023 00-30-37](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/3b730bf2-5801-4ee5-a8c6-11b8a97317c4)


- [ ] 질문 등록 페이지에서 저장된 질문 템플릿의 내용을 불러올 수 있습니다.
- [ ] 질문 등록 페이지에서 작성한 질문을 새로운 템플릿으로 저장할 수 있습니다.
- [ ] 질문 수정 페이지에서 저장된 질문 템플릿의 내용을 불러올 수 있습니다.
- [ ] 질문 수정 페이지에서 작성한 질문을 새로운 템플릿으로 저장할 수 있습니다.


## 🚧 특이 사항

생략


## 🚨관련 이슈

close #256