### PR TITLE
🚨 Fix(#298): 상세 페이지 좋아요 api 수정 및 에러 페이지 새로고침 버튼 추가

### DIFF
--- a/src/app/(steady)/steady/detail/[id]/page.tsx
+++ b/src/app/(steady)/steady/detail/[id]/page.tsx
@@ -172,20 +172,12 @@ const SteadyDetailPage = ({ params }: { params: { id: string } }) => {
                 />
               }
               trigger={
-                <button onClick={() => mutate(steadyId)}>
-                  {steadyDetailsData.isLiked ? (
-                    <Icon
-                      name="heart"
-                      size={30}
-                      color="text-st-red"
-                    />
-                  ) : (
-                    <Icon
-                      name="empty-heart"
-                      size={30}
-                      color="text-black"
-                    />
-                  )}
+                <button>
+                  <Icon
+                    name="empty-heart"
+                    size={30}
+                    color="text-black"
+                  />
                 </button>
               }
             >

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -9,7 +9,13 @@ import type { AxiosError } from "axios";
 import type { ErrorResponse } from "@/services/types";
 import Button, { buttonSize } from "@/components/_common/Button";
 
-const Error = ({ error }: { error: AxiosError<ErrorResponse> }) => {
+const Error = ({
+  error,
+  reset,
+}: {
+  error: AxiosError<ErrorResponse>;
+  reset: VoidFunction;
+}) => {
   const router = useRouter();
   const { toast } = useToast();
   useEffect(() => {
@@ -35,13 +41,23 @@ const Error = ({ error }: { error: AxiosError<ErrorResponse> }) => {
         width={200}
         height={100}
       />
-      <div className="text-30 font-bold">알 수 없는 에러가 발생했습니다.</div>
-      <Button
-        className={`${buttonSize.md} bg-st-primary text-st-white`}
-        onClick={() => router.replace("/")}
-      >
-        홈으로
-      </Button>
+      <div className="font-bold max-sm:text-26 sm:text-26 md:text-26 lg:text-28 xl:text-30">
+        알 수 없는 에러가 발생했습니다.
+      </div>
+      <div className="flex gap-20">
+        <Button
+          className={`${buttonSize.md} bg-st-primary text-st-white`}
+          onClick={() => reset()}
+        >
+          새로고침
+        </Button>
+        <Button
+          className={`${buttonSize.md} bg-st-primary text-st-white`}
+          onClick={() => router.replace("/")}
+        >
+          홈으로
+        </Button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 📑 구현 사항

- [x] 상세 페이지 좋아요 api 이슈 (비로그인 상태 시에도 api 요청 날라감)
- [x] 에러 페이지 reload 버튼 만들기
<img width="1280" alt="image" src="https://github.com/Team-Blitz-Steady/steady-client/assets/109654823/210c8483-cb0f-4b24-b49f-0af66d09c7df">

## 🚧 특이 사항

- [ ] 


## 🚨관련 이슈

close #298