### PR TITLE
🚨 Fix(#300): 3차 QA 부분 수정

### DIFF
--- a/src/components/_common/AppBar/index.tsx
+++ b/src/components/_common/AppBar/index.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import HeaderLogo from "@/images/headerLogo.svg";
 import Logo from "@/images/logo.svg";
 import { cn } from "@/lib/utils";
 import useAuthStore from "@/stores/isAuth";
+import getMyProfile from "@/services/user/getMyProfile";
 import Dropdown from "@/components/_common/Dropdown";
 import NotificationPopup from "@/components/_common/NotificationPopup";
 import LoginModal from "../Modal/LoginModal";
@@ -18,6 +20,15 @@ export const appBarTextStyles = "text-lg font-bold";
 
 const AppBar = ({ className }: AppBarProps) => {
   const { isAuth } = useAuthStore();
+  const [userProfileImageSrc, setUserProfileImageSrc] = useState(Logo);
+
+  useEffect(() => {
+    if (isAuth) {
+      getMyProfile().then((res) => {
+        setUserProfileImageSrc(res.profileImage);
+      });
+    }
+  }, []);
 
   return (
     <div
@@ -56,7 +67,7 @@ const AppBar = ({ className }: AppBarProps) => {
           >
             <Image
               className="rounded-full border-1"
-              src={Logo}
+              src={userProfileImageSrc}
               alt="스테디 로고"
               width={45}
               height={45}

--- a/src/components/_common/Dropdown/index.tsx
+++ b/src/components/_common/Dropdown/index.tsx
@@ -31,7 +31,7 @@ const Dropdown = ({ children, options }: DropdownProps) => {
           {children}
         </Button>
       </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
+      <DropdownMenu.Content onInteractOutside={() => setOpen(false)}>
         {options.map((option, idx) => (
           <DropdownMenu.Item
             key={idx}

--- a/src/components/_common/Editor/InitializedMDXEditor.tsx
+++ b/src/components/_common/Editor/InitializedMDXEditor.tsx
@@ -6,6 +6,10 @@ import { useEffect } from "react";
 import {
   BlockTypeSelect,
   BoldItalicUnderlineToggles,
+  ChangeCodeMirrorLanguage,
+  ConditionalContents,
+  DiffSourceToggleWrapper,
+  InsertCodeBlock,
   ListsToggle,
   MDXEditor,
   type MDXEditorMethods,
@@ -14,6 +18,7 @@ import {
   UndoRedo,
   codeBlockPlugin,
   codeMirrorPlugin,
+  diffSourcePlugin,
   headingsPlugin,
   imagePlugin,
   linkDialogPlugin,
@@ -54,20 +59,44 @@ export default function InitializedMDXEditor({
         codeBlockPlugin({ defaultCodeBlockLanguage: "txt" }),
         codeMirrorPlugin({
           codeBlockLanguages: {
+            java: "Java",
             js: "JavaScript",
+            python: "Python",
+            c: "C",
             css: "CSS",
             txt: "text",
           },
         }),
+        diffSourcePlugin({
+          diffMarkdown: "An older version",
+          viewMode: "rich-text",
+        }),
         toolbarPlugin({
           toolbarContents: () => (
             <>
-              <UndoRedo />
-              <BoldItalicUnderlineToggles />
-              <ListsToggle />
-              <Separator />
-              <BlockTypeSelect />
-              <Separator />
+              <DiffSourceToggleWrapper>
+                <UndoRedo />
+                <BoldItalicUnderlineToggles />
+                <ListsToggle />
+                <Separator />
+                <BlockTypeSelect />
+                <Separator />
+                <ConditionalContents
+                  options={[
+                    {
+                      when: (editor) => editor?.editorType === "codeblock",
+                      contents: () => <ChangeCodeMirrorLanguage />,
+                    },
+                    {
+                      fallback: () => (
+                        <>
+                          <InsertCodeBlock />
+                        </>
+                      ),
+                    },
+                  ]}
+                />
+              </DiffSourceToggleWrapper>
             </>
           ),
         }),

--- a/src/components/_common/NotificationPopup/index.tsx
+++ b/src/components/_common/NotificationPopup/index.tsx
@@ -124,7 +124,10 @@ const NotificationPopup = () => {
         </div>
       </PopoverTrigger>
 
-      <PopoverContent className={"h-300 w-350 p-16 pb-40"}>
+      <PopoverContent
+        className={"h-300 w-350 p-16 pb-40"}
+        onInteractOutside={() => setNotificationMenuOpen(false)}
+      >
         <ScrollArea
           className={"h-full w-full rounded-md"}
           scrollBarClassName={"hidden"}

--- a/src/components/_common/NotificationPopup/index.tsx
+++ b/src/components/_common/NotificationPopup/index.tsx
@@ -103,10 +103,11 @@ const NotificationPopup = () => {
 
   return (
     <Popover open={notificationMenuOpen}>
-      <PopoverTrigger
-        onClick={() => setNotificationMenuOpen(!notificationMenuOpen)}
-      >
-        <div className={"relative h-25 w-25"}>
+      <PopoverTrigger>
+        <div
+          className={"relative h-25 w-25"}
+          onClick={() => setNotificationMenuOpen((prev) => !prev)}
+        >
           {freshCount > 0 && (
             <div
               className={
@@ -126,7 +127,16 @@ const NotificationPopup = () => {
 
       <PopoverContent
         className={"h-300 w-350 p-16 pb-40"}
-        onInteractOutside={() => setNotificationMenuOpen(false)}
+        onPointerDownOutside={(event) => {
+          const target = event.target as HTMLElement;
+          if (
+            target?.tagName.toLowerCase() === "path" ||
+            target?.tagName.toLowerCase() === "svg"
+          ) {
+            return;
+          }
+          setNotificationMenuOpen(false);
+        }}
       >
         <ScrollArea
           className={"h-full w-full rounded-md"}

--- a/src/components/_common/Selector/Multi/index.tsx
+++ b/src/components/_common/Selector/Multi/index.tsx
@@ -43,7 +43,7 @@ const MultiSelector = ({
     (event: KeyboardEvent<HTMLInputElement>) => {
       const input = inputRef.current;
       if (input !== null) {
-        if (event.key === "Delete" || event.key === "Backspace") {
+        if (event.key === "Backspace") {
           if (input.value === "") {
             setSelected((prev) => {
               const newSelected = [...prev];
@@ -88,11 +88,6 @@ const MultiSelector = ({
                 {item.label}
                 <button
                   className="ml-4 rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      handleUnselect(item);
-                    }
-                  }}
                   onMouseDown={(e) => {
                     e.preventDefault();
                     e.stopPropagation();


### PR DESCRIPTION
## 📑 구현 사항

- [ ] Dropdown menu, Popover 컴포넌트 열림 상태에서 외부 클릭 시 닫히도록 변경하였습니다. 기존의 토글 동작도 유지됩니다.
![Nov-30-2023 22-23-48](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/f217cb08-0b4f-459c-bf40-8b39ac7c8e8c)

- [ ] 헤더의 이미지를 실제 프로필 이미지로 변경하였습니다.
<img width="477" alt="스크린샷 2023-11-30 오후 10 22 53" src="https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/025e5987-87f5-44da-8daa-c21c264452c1">

- [ ] 마크다운 에디터의 코드 블록을 지우기 위한 설정을 추가하였습니다 (source 모드로 변경하고 해당 마크다운 데이터 삭제해주기...)
![Nov-30-2023 22-24-28](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/4f75bfde-e86a-45db-9b56-f2b02b973d3a)

## 🚧 특이 사항

- MultiSelector 이슈는 주말에 찾아서 고치겠습니닷..


## 🚨관련 이슈

close #300