### PR TITLE
🚨 Fix(#319): 4차 QA 사항 반영

### DIFF
--- a/src/app/(user-menu)/mypage/page.tsx
+++ b/src/app/(user-menu)/mypage/page.tsx
@@ -315,7 +315,7 @@ const MyProfilePage = () => {
                     "flex h-30 w-718 items-center justify-center gap-15 text-2xl italic text-st-gray-250",
                   )}
                 >
-                  {`"${bio}"` ?? "한 줄 소개를 입력해주세요."}
+                  {`"${bio ?? "한 줄 소개로 자신을 표현해보세요!"}"`}
                   <button onClick={() => setIsEditingBio(true)}>
                     <Icon
                       name="pencil"

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -27,7 +27,7 @@ const Error = ({
     ) {
       toast({
         description:
-          "토큰이 만료되거나 유효하지 않습니다. 다시 로그인해주세요.",
+          "로그인 정보가 만료되거나 유효하지 않습니다. 다시 로그인해주세요.",
         variant: "red",
       });
       router.push("/logout");

--- a/src/components/_common/Dropdown/index.tsx
+++ b/src/components/_common/Dropdown/index.tsx
@@ -33,18 +33,16 @@ const Dropdown = ({ children, options }: DropdownProps) => {
       </DropdownMenu.Trigger>
       <DropdownMenu.Content onInteractOutside={() => setOpen(false)}>
         {options.map((option, idx) => (
-          <DropdownMenu.Item
+          <Link
+            href={option.linkTo}
+            onClick={() => setOpen(false)}
             key={idx}
             className={"p-0 hover:bg-st-primary"}
           >
-            <Link
-              href={option.linkTo}
-              onClick={() => setOpen(false)}
-              className="flex h-full w-full items-center justify-center"
-            >
-              <div className="p-10">{option.label}</div>
-            </Link>
-          </DropdownMenu.Item>
+            <DropdownMenu.Item className={"cursor-pointer hover:bg-st-primary"}>
+              {option.label}
+            </DropdownMenu.Item>
+          </Link>
         ))}
       </DropdownMenu.Content>
     </DropdownMenu.Root>

--- a/src/components/_common/Input/index.tsx
+++ b/src/components/_common/Input/index.tsx
@@ -118,7 +118,7 @@ const Input = ({
             className="h-60 w-full rounded-12 p-5 text-xl font-bold outline-none"
             type="text"
             defaultValue={initialValue}
-            placeholder="한 줄 소개로 자신을 표현해 주세요!"
+            placeholder="한 줄 소개로 자신을 표현해보세요!"
             onChange={(event) => {
               onValueChange?.(event.target.value);
             }}

--- a/src/components/_common/NotificationPopup/index.tsx
+++ b/src/components/_common/NotificationPopup/index.tsx
@@ -54,7 +54,7 @@ const NotificationPopup = () => {
     if (notificationsError) {
       if (notificationsError.response?.data.code === "A002") {
         toast({
-          description: "토큰이 존재하지 않습니다. 다시 로그인해주세요.",
+          description: "로그인 정보가 존재하지 않습니다. 다시 로그인해주세요.",
           variant: "red",
         });
         setIsAuth(false);

--- a/src/components/_common/ProfileImageUpload/index.tsx
+++ b/src/components/_common/ProfileImageUpload/index.tsx
@@ -21,6 +21,7 @@ import Button, { buttonSize } from "@/components/_common/Button";
 import { MyProfileKey } from "@/constants/queryKeys";
 
 const ProfileImageUpload = ({ userData }: { userData: MyProfileType }) => {
+  const [open, setOpen] = useState("item-hidden");
   const [imageSrc, setImageSrc] = useState("");
   const [imageFile, setImageFile] = useState<File>();
   const { toast } = useToast();
@@ -64,6 +65,7 @@ const ProfileImageUpload = ({ userData }: { userData: MyProfileType }) => {
             description: "프로필 이미지가 수정되었습니다.",
             variant: "green",
           });
+          setOpen("item-hidden");
         });
         setImageSrc("");
         setImageFile(undefined);
@@ -76,6 +78,8 @@ const ProfileImageUpload = ({ userData }: { userData: MyProfileType }) => {
       type="single"
       collapsible
       className="h-30"
+      value={open}
+      onValueChange={(value) => setOpen(value)}
     >
       <AccordionItem value="item-1">
         <AccordionTrigger
@@ -141,6 +145,10 @@ const ProfileImageUpload = ({ userData }: { userData: MyProfileType }) => {
           </div>
         </AccordionContent>
       </AccordionItem>
+      <AccordionItem
+        value={"item-hidden"}
+        className={"hidden"}
+      ></AccordionItem>
     </Accordion>
   );
 };


### PR DESCRIPTION
## 📑 구현 사항

- [x] 토큰의 상태에 따른 토스트 에러 메시지의 내용을 수정했습니다 (토큰 -> "로그인 정보" 용어 대체)
- [x] 프로필 사진 수정 시 아코디언이 자동으로 닫히도록 변경했습니다
- [x] Dropdown menu의 Item 선택 시 텍스트 외 영역을 클릭해도 선택되도록 변경했습니다.
- [x] 한 줄 소개 미입력 시 대체 문구가 보이도록 변경했습니다


## 🚧 특이 사항



## 🚨관련 이슈

close #319