### PR TITLE
🚨 Fix(#347): 스테디 등록 과정 데이터 유실 오류 수정

### DIFF
--- a/src/app/(steady)/steady/create/page.tsx
+++ b/src/app/(steady)/steady/create/page.tsx
@@ -50,7 +50,8 @@ import {
 
 const CreateSteadyPage = () => {
   const router = useRouter();
-  const { steadyState, setSteadyState } = useCreateSteadyStore();
+  const { steadyState, setSteadyState, resetSteadyState } =
+    useCreateSteadyStore();
   const editorRef = useRef<MDXEditorMethods>(null);
   const [editorLoaded, setEditorLoaded] = useState(false);
   const steadyForm = useForm<SteadyStateType>({
@@ -83,6 +84,8 @@ const CreateSteadyPage = () => {
   const handleCancelProcess = () => {
     if (steadyState) {
       useCreateSteadyStore.persist.clearStorage();
+      steadyForm.reset();
+      resetSteadyState();
     }
     router.replace("/");
   };

--- a/src/app/(steady)/steady/create/page.tsx
+++ b/src/app/(steady)/steady/create/page.tsx
@@ -393,11 +393,13 @@ const CreateSteadyPage = () => {
               render={({ field }) => (
                 <FormItem
                   className={
-                    "my-10 h-720 w-full rounded-10 border-2 border-st-gray-75"
+                    "my-10 w-full rounded-10 border-2 border-st-gray-75"
                   }
                 >
                   <RichEditor
-                    contentEditableClassName={"prose"}
+                    contentEditableClassName={"prose h-640 w-full"}
+                    className={"h-700"}
+                    ref={editorRef}
                     onChange={(markdown) => {
                       unified()
                         .use(remarkParse)

--- a/src/app/(steady)/steady/create/questions/page.tsx
+++ b/src/app/(steady)/steady/create/questions/page.tsx
@@ -25,7 +25,7 @@ const CreateQuestionsPage = () => {
   const [isTemplateTitleSetting, setIsTemplateTitleSetting] = useState(false);
   const { toast } = useToast();
   const router = useRouter();
-  const { steadyState } = useCreateSteadyStore();
+  const { steadyState, resetSteadyState } = useCreateSteadyStore();
 
   useEffect(() => {
     if (!steadyState || Object.keys(steadyState).length === 0) {
@@ -103,6 +103,7 @@ const CreateQuestionsPage = () => {
           variant: "green",
         });
         useCreateSteadyStore.persist.clearStorage();
+        resetSteadyState();
         router.push("/");
       })
       .catch(() => {

--- a/src/stores/createSteadyData.ts
+++ b/src/stores/createSteadyData.ts
@@ -8,6 +8,7 @@ interface CreateSteadyState {
   steadyState: SteadyStateType;
   // eslint-disable-next-line no-unused-vars
   setSteadyState: (steadyState: SteadyStateType) => void;
+  resetSteadyState: () => void;
 }
 
 const useCreateSteadyStore = create(
@@ -15,6 +16,7 @@ const useCreateSteadyStore = create(
     (set) => ({
       steadyState: {} as SteadyStateType,
       setSteadyState: (steadyState: SteadyStateType) => set({ steadyState }),
+      resetSteadyState: () => set({ steadyState: {} as SteadyStateType }),
     }),
     {
       name: CreateSteadyStorageKey,


### PR DESCRIPTION
## 📑 구현 사항

- [x] SteadyState라는 persist 미들웨어가 적용된 zustand 상태가 있는데, 여기서 각 폼 UI와 폼 데이터의 초기 데이터를 로드하도록 변경하였습니다
- [x] 등록을 취소하거나 등록이 성공했을 때 로컬 스토리지에서 데이터를 지워주는 것에 더해, 초기화 로직까지 포함하도록 수정하였습니다.
- [x] 에디터의 하단을 클릭했을 때에도 커서가 활성화되도록 수정하였습니다

![Feb-26-2024 15-41-28](https://github.com/Team-Blitz-Steady/steady-client/assets/69716992/7356ef90-1531-4331-bcc0-eb5df940925b)



## 🚧 특이 사항




## 🚨관련 이슈

close #347 